### PR TITLE
install guide 변경(via readme.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Alpha: [![Build Status](https://travis-ci.org/EOSYS-io/eoshub.io.svg?branch=alph
 
 ## Setup
 ```
-git clone git@github.com:chain-partners/eoshub.io.git
+git clone git@github.com:EOSYS-io/eoshub.io.git
 cd eoshub.io
 gem install bundler
 bundle install
@@ -30,6 +30,10 @@ cp ${MASTER_KEY_PATH}/master.key config
 touch .env
 echo "DATABASE_URL=postgresql://${OSX_USERNAME}:@localhost/eoshub_dev" >> .env
 echo "TEST_DATABASE_URL=postgresql://${OSX_USERNAME}:@localhost/eoshub_test" >> .env
+  
+yarn install
+yarn run elm package install -y
+  
 rails db:create
 ```
 


### PR DESCRIPTION
readme.md

1. change clone repo
체인파트너스에서 eosys-io 저장소로 클론 대상을 변경했습니다.

2. add install command(yarn)
db생성전 yarn install 명령을 추가했습니다.(크게 중요하진 않습니다만, 사전 설치되어 있어야 해서 step by step 개념으로 접근..)