### PR TITLE
add hyper link to page global title element

### DIFF
--- a/app/frontend/src/elm/Sidebar.elm
+++ b/app/frontend/src/elm/Sidebar.elm
@@ -70,11 +70,10 @@ type Message
 view : Model -> List (Html Message)
 view { state, wallet, language, fold } =
     [ header []
-        [ h1
-            [ style [ ( "cursor", "pointer" ) ]
-            , onClick (ExternalMessage (ExternalMessage.ChangeUrl "/"))
+        [ h1 []
+            [ a [ href "/" ]
+                [ text "eoshub" ]
             ]
-            [ text "eoshub" ]
         , button
             [ type_ "button"
             , id "lnbToggleButton"


### PR DESCRIPTION
w3c에 정의된 html 스펙과 의미와 구조에 맞게 페이지 타이틀 element에 링크 부여하였습니다.