### PR TITLE
Add a notification view to the account creation pages

### DIFF
--- a/app/frontend/src/elm/Component/Account/AccountComponent.elm
+++ b/app/frontend/src/elm/Component/Account/AccountComponent.elm
@@ -26,7 +26,6 @@ import Translation exposing (Language)
 import Route exposing (Route(..), parseLocation)
 import Translation exposing (Language)
 import Util.Flags exposing (Flags)
-import View.Notification as Notification
 
 
 -- MODEL
@@ -46,7 +45,6 @@ type alias Model =
     { page : Page
     , confirmToken : String
     , language : Language
-    , notification : Notification.Model
     }
 
 
@@ -64,14 +62,12 @@ initModel location =
                 { page = page
                 , confirmToken = confirmToken
                 , language = Translation.Korean
-                , notification = Notification.initModel
                 }
 
             _ ->
                 { page = page
                 , confirmToken = ""
                 , language = Translation.Korean
-                , notification = Notification.initModel
                 }
 
 
@@ -87,7 +83,6 @@ type Message
     | CreatedMessage Created.Message
     | CreateMessage Create.Message
     | OnLocationChange Location
-    | NotificationMessage Notification.Message
 
 
 initCmd : Model -> Cmd Message
@@ -112,12 +107,12 @@ initCmd { page, confirmToken } =
 
 
 view : Model -> Html Message
-view { language, page, notification } =
+view { language, page } =
     let
         newContentHtml =
             case page of
                 ConfirmEmailPage subModel ->
-                    Html.map ConfirmEmailMessage (ConfirmEmail.view subModel)
+                    Html.map ConfirmEmailMessage (ConfirmEmail.view subModel language)
 
                 EmailConfirmedPage subModel ->
                     Html.map EmailConfirmedMessage (EmailConfirmed.view subModel)
@@ -132,15 +127,12 @@ view { language, page, notification } =
                     Html.map CreatedMessage (Created.view subModel)
 
                 CreatePage subModel ->
-                    Html.map CreateMessage (Create.view subModel)
+                    Html.map CreateMessage (Create.view subModel language)
 
                 _ ->
                     NotFound.view language
     in
-        div []
-            [ newContentHtml
-            , Html.map NotificationMessage (Notification.view notification "" language)
-            ]
+        newContentHtml
 
 
 

--- a/app/frontend/src/elm/Component/Account/Page/ConfirmEmail.elm
+++ b/app/frontend/src/elm/Component/Account/Page/ConfirmEmail.elm
@@ -148,7 +148,13 @@ view { validationMsg, requested, emailValid, inputValid, notification } language
                 [ text "받으신 메일의 링크를 클릭해주세요." ]
             , form [ action "" ]
                 [ text "        "
-                , input [ placeholder "example@email.com", attribute "required" "", type_ "email", attribute inputValid "", onInput ValidateEmail ]
+                , input
+                    [ placeholder "example@email.com"
+                    , attribute "required" ""
+                    , type_ "email"
+                    , attribute inputValid ""
+                    , onInput ValidateEmail
+                    ]
                     []
                 , span [ class "validate" ]
                     [ text validationMsg ]

--- a/app/frontend/src/elm/Component/Main/MainComponent.elm
+++ b/app/frontend/src/elm/Component/Main/MainComponent.elm
@@ -167,14 +167,6 @@ view { page, header, notification, sidebar, showUnderConstruction } =
                 _ ->
                     NotFound.view sidebar.language
 
-        notificationParameter =
-            case page of
-                TransferPage { transfer } ->
-                    transfer.to
-
-                _ ->
-                    ""
-
         underConstructionView =
             div
                 [ id "underConstruction"
@@ -233,7 +225,6 @@ view { page, header, notification, sidebar, showUnderConstruction } =
                 , Html.map NotificationMessage
                     (Notification.view
                         notification
-                        notificationParameter
                         sidebar.language
                     )
                 , underConstructionView
@@ -291,14 +282,23 @@ update message ({ page, notification, header, sidebar } as model) =
             ( { model | showUnderConstruction = True }, Cmd.none )
 
         ( UpdatePushActionResponse resp, _ ) ->
-            ( { model
-                | notification =
-                    { content = resp |> decodePushActionResponse
-                    , open = True
-                    }
-              }
-            , Cmd.none
-            )
+            let
+                notificationParameter =
+                    case page of
+                        TransferPage { transfer } ->
+                            transfer.to
+
+                        _ ->
+                            ""
+            in
+                ( { model
+                    | notification =
+                        { content = decodePushActionResponse resp notificationParameter
+                        , open = True
+                        }
+                  }
+                , Cmd.none
+                )
 
         ( OnLocationChange location, _ ) ->
             let

--- a/app/frontend/src/elm/Translation.elm
+++ b/app/frontend/src/elm/Translation.elm
@@ -15,7 +15,9 @@ type alias Messages =
 
 
 type I18n
-    = Login
+    = EmptyMessage
+    | DebugMessage String
+    | Login
     | NewAccount
     | OpenCloseSidebar
     | Hello
@@ -69,6 +71,9 @@ type I18n
     | UnderConstruction2
     | UnderConstructionDesc1
     | UnderConstructionDesc2
+    | ConfirmEmailSent
+    | AlreadyExistEmail
+    | AccountCreationFailure
 
 
 translate : Language -> I18n -> String
@@ -96,6 +101,18 @@ translate language i18n =
 getMessages : I18n -> Messages
 getMessages i18n =
     case i18n of
+        EmptyMessage ->
+            { korean = ""
+            , english = ""
+            , chinese = ""
+            }
+
+        DebugMessage error ->
+            { korean = error
+            , english = error
+            , chinese = error
+            }
+
         Login ->
             { korean = "로그인"
             , english = "Sign In"
@@ -418,4 +435,22 @@ getMessages i18n =
             { korean = "조금만 기다려주세요!"
             , english = "We appreciate your patience!"
             , chinese = "请各位尽情等待!"
+            }
+
+        ConfirmEmailSent ->
+            { korean = "이메일을 확인해주세요!"
+            , english = "Please check your email!"
+            , chinese = "请检查您的电子邮件！"
+            }
+
+        AlreadyExistEmail ->
+            { korean = "이미 존재하는 이메일입니다."
+            , english = "This email already exists"
+            , chinese = "此电子邮件已存在"
+            }
+
+        AccountCreationFailure ->
+            { korean = "EOS 계정 생성에 실패했습니다."
+            , english = "Failed to create EOS account"
+            , chinese = "无法创建EOS帐户"
             }

--- a/app/frontend/src/elm/Util/WalletDecoder.elm
+++ b/app/frontend/src/elm/Util/WalletDecoder.elm
@@ -9,7 +9,7 @@ module Util.WalletDecoder
         )
 
 import Dict exposing (Dict, fromList)
-import Translation exposing (I18n(TransferSucceeded, TransferFailed, UnknownError))
+import Translation exposing (I18n(EmptyMessage, DebugMessage, TransferSucceeded, TransferFailed, UnknownError, CheckDetail, CheckError))
 import View.Notification as Notification
 
 
@@ -54,8 +54,8 @@ actionFailMessages =
     fromList [ ( "transfer", TransferFailed ) ]
 
 
-decodePushActionResponse : PushActionResponse -> Notification.Content
-decodePushActionResponse { code, type_, message, action } =
+decodePushActionResponse : PushActionResponse -> String -> Notification.Content
+decodePushActionResponse { code, type_, message, action } i18nParam =
     case code of
         200 ->
             let
@@ -64,13 +64,16 @@ decodePushActionResponse { code, type_, message, action } =
             in
                 case value of
                     Just messageFunction ->
-                        Notification.Ok messageFunction
+                        Notification.Ok
+                            { message = i18nParam |> messageFunction
+                            , detail = CheckDetail
+                            }
 
                     -- This case should not happen!
                     Nothing ->
                         Notification.Error
                             { message = UnknownError
-                            , detail = ""
+                            , detail = CheckError
                             }
 
         _ ->
@@ -82,13 +85,13 @@ decodePushActionResponse { code, type_, message, action } =
                     Just messageFunction ->
                         Notification.Error
                             { message = messageFunction (toString code)
-                            , detail = type_ ++ "\n" ++ message
+                            , detail = DebugMessage (type_ ++ "\n" ++ message)
                             }
 
                     Nothing ->
                         Notification.Error
                             { message = UnknownError
-                            , detail = ""
+                            , detail = CheckError
                             }
 
 

--- a/app/frontend/src/elm/View/Notification.elm
+++ b/app/frontend/src/elm/View/Notification.elm
@@ -99,15 +99,33 @@ view { content, open } language =
 messageBox : ( String, String, String ) -> Language -> Html Message
 messageBox ( mainText, classText, detailText ) language =
     div [ class classText ]
-        [ p [] [ text mainText ]
-        , if not (String.isEmpty detailText) then
-            a [] [ text detailText ]
-          else
-            a [] []
-        , button
-            [ type_ "button"
-            , class "icon close button"
-            , onClick CloseNotification
+        (if String.isEmpty detailText then
+            [ messageBoxMainText mainText
+            , messageBoxButton language
             ]
-            [ text (translate language Close) ]
+         else
+            [ messageBoxMainText mainText
+            , messageBoxDetailText detailText
+            , messageBoxButton language
+            ]
+        )
+
+
+messageBoxMainText : String -> Html Message
+messageBoxMainText mainText =
+    p [] [ text mainText ]
+
+
+messageBoxDetailText : String -> Html Message
+messageBoxDetailText detailText =
+    a [] [ text detailText ]
+
+
+messageBoxButton : Language -> Html Message
+messageBoxButton language =
+    button
+        [ type_ "button"
+        , class "icon close button"
+        , onClick CloseNotification
         ]
+        [ text (translate language Close) ]

--- a/app/frontend/src/elm/View/Notification.elm
+++ b/app/frontend/src/elm/View/Notification.elm
@@ -14,7 +14,7 @@ module View.Notification
 import Html exposing (Html, div, text, p, a, button)
 import Html.Attributes exposing (class, type_, id)
 import Html.Events exposing (onClick)
-import Translation exposing (Language, translate, I18n(CheckDetail, CheckError, Close))
+import Translation exposing (Language, translate, I18n(Close))
 
 
 -- MESSAGE
@@ -28,14 +28,20 @@ type Message
 -- MODEL
 
 
+type alias OkDetail =
+    { message : I18n
+    , detail : I18n
+    }
+
+
 type alias ErrorDetail =
     { message : I18n
-    , detail : String
+    , detail : I18n
     }
 
 
 type Content
-    = Ok (String -> I18n)
+    = Ok OkDetail
     | Error ErrorDetail
     | None
 
@@ -57,21 +63,21 @@ initModel =
 -- VIEW
 
 
-view : Model -> String -> Language -> Html Message
-view { content, open } i18nParam language =
+view : Model -> Language -> Html Message
+view { content, open } language =
     let
         texts =
             case content of
-                Ok messageGenerator ->
-                    ( translate language (i18nParam |> messageGenerator)
+                Ok { message, detail } ->
+                    ( translate language message
                     , "view success"
-                    , translate language CheckDetail
+                    , translate language detail
                     )
 
-                Error { message } ->
+                Error { message, detail } ->
                     ( translate language message
                     , "view fail"
-                    , translate language CheckError
+                    , translate language detail
                     )
 
                 _ ->
@@ -94,7 +100,10 @@ messageBox : ( String, String, String ) -> Language -> Html Message
 messageBox ( mainText, classText, detailText ) language =
     div [ class classText ]
         [ p [] [ text mainText ]
-        , a [] [ text detailText ]
+        , if not (String.isEmpty detailText) then
+            a [] [ text detailText ]
+          else
+            a [] []
         , button
             [ type_ "button"
             , class "icon close button"

--- a/test/frontend/elm/Test/Component/Account/AccountComponent.elm
+++ b/test/frontend/elm/Test/Component/Account/AccountComponent.elm
@@ -98,7 +98,6 @@ tests =
                                 { page = expectedPage
                                 , confirmToken = confirmToken
                                 , language = Translation.Korean
-                                , notification = Notification.initModel
                                 }
                         in
                             Expect.equal expectedCmd (initCmd model)

--- a/test/frontend/elm/Test/Component/Account/Page/ConfirmEmail.elm
+++ b/test/frontend/elm/Test/Component/Account/Page/ConfirmEmail.elm
@@ -4,16 +4,17 @@ import Expect
 import Http
 import Component.Account.Page.ConfirmEmail exposing (..)
 import Test exposing (..)
+import View.Notification as Notification
 
 
 model : Model
 model =
     { email = "test@chain.partners"
     , validationMsg = "Please enter an email address."
-    , requestStatus = { msg = "" }
     , requested = False
     , emailValid = False
     , inputValid = "invalid"
+    , notification = Notification.initModel
     }
 
 

--- a/test/frontend/elm/Test/Component/Account/Page/Create.elm
+++ b/test/frontend/elm/Test/Component/Account/Page/Create.elm
@@ -4,16 +4,17 @@ import Expect
 import Http
 import Component.Account.Page.Create exposing (..)
 import Test exposing (..)
+import View.Notification as Notification
 
 
 model : Model
 model =
     { accountName = "testtesttest"
-    , requestStatus = { msg = "" }
     , pubkey = "12o9347512f1oh923"
     , validation = False
     , validationMsg = ""
     , requestSuccess = False
+    , notification = Notification.initModel
     }
 
 

--- a/test/frontend/elm/Test/Component/Main/MainComponent.elm
+++ b/test/frontend/elm/Test/Component/Main/MainComponent.elm
@@ -7,7 +7,7 @@ import Component.Main.Page.Search as Search
 import Component.Main.Page.Transfer as Transfer
 import Component.Main.Page.Voting as Voting
 import Test exposing (..)
-import Translation exposing (I18n(TransferSucceeded))
+import Translation exposing (I18n(TransferSucceeded, CheckDetail))
 import Util.WalletDecoder exposing (WalletStatus(Authenticated))
 import View.Notification
 
@@ -55,14 +55,22 @@ tests =
                 [ test "UpdatePushActionResponse" <|
                     \() ->
                         let
-                            ({ notification } as model) =
-                                initModel location
+                            ({ notification, page } as model) =
+                                initModel { location | pathname = "/transfer" }
+
+                            notificationParameter =
+                                case page of
+                                    TransferPage { transfer } ->
+                                        transfer.to
+
+                                    _ ->
+                                        ""
 
                             expectedModel =
                                 { model
                                     | notification =
                                         { notification
-                                            | content = View.Notification.Ok TransferSucceeded
+                                            | content = View.Notification.Ok { message = (TransferSucceeded notificationParameter), detail = CheckDetail }
                                             , open = True
                                         }
                                 }

--- a/test/frontend/elm/Test/Component/Main/MainComponent.elm
+++ b/test/frontend/elm/Test/Component/Main/MainComponent.elm
@@ -70,7 +70,11 @@ tests =
                                 { model
                                     | notification =
                                         { notification
-                                            | content = View.Notification.Ok { message = (TransferSucceeded notificationParameter), detail = CheckDetail }
+                                            | content =
+                                                View.Notification.Ok
+                                                    { message = (TransferSucceeded notificationParameter)
+                                                    , detail = CheckDetail
+                                                    }
                                             , open = True
                                         }
                                 }

--- a/test/frontend/elm/Test/Util/WalletDecoder.elm
+++ b/test/frontend/elm/Test/Util/WalletDecoder.elm
@@ -2,7 +2,7 @@ module Test.Util.WalletDecoder exposing (tests)
 
 import Expect
 import Test exposing (..)
-import Translation exposing (I18n(TransferSucceeded, TransferFailed, UnknownError))
+import Translation exposing (I18n(TransferSucceeded, TransferFailed, UnknownError, CheckDetail, CheckError, DebugMessage))
 import Util.WalletDecoder exposing (..)
 import View.Notification
 
@@ -18,75 +18,84 @@ response =
 
 tests : Test
 tests =
-    describe "Util.WalletDecoder module"
-        [ describe "decodePushActionResponse"
-            [ describe "transfer"
-                [ test "200" <|
+    let
+        transfer =
+            { from = "from"
+            , to = "to"
+            , quantity = "300"
+            , memo = "memo"
+            }
+    in
+        describe "Util.WalletDecoder module"
+            [ describe "decodePushActionResponse"
+                [ describe "transfer"
+                    [ test "200" <|
+                        \() ->
+                            Expect.equal
+                                (View.Notification.Ok { message = TransferSucceeded transfer.to, detail = CheckDetail })
+                                (decodePushActionResponse response transfer.to)
+                    , test "500 on unknownAction" <|
+                        \() ->
+                            Expect.equal
+                                (View.Notification.Error { message = UnknownError, detail = CheckError })
+                                (decodePushActionResponse { response | action = "unknown" } transfer.to)
+                    , test "402" <|
+                        \() ->
+                            Expect.equal
+                                (View.Notification.Error
+                                    { message = TransferFailed "402"
+                                    , detail = DebugMessage "account_missing\nMissing required accounts, repull the identity"
+                                    }
+                                )
+                                (decodePushActionResponse
+                                    { response
+                                        | code = 402
+                                        , type_ = "account_missing"
+                                        , message = "Missing required accounts, repull the identity"
+                                    }
+                                    transfer.to
+                                )
+                    ]
+                ]
+            , describe "decodeWalletResponse"
+                [ test "authenticated" <|
                     \() ->
                         Expect.equal
-                            (View.Notification.Ok TransferSucceeded)
-                            (decodePushActionResponse response)
-                , test "500 on unknownAction" <|
-                    \() ->
-                        Expect.equal
-                            (View.Notification.Error { message = UnknownError, detail = "" })
-                            (decodePushActionResponse { response | action = "unknown" })
-                , test "402" <|
-                    \() ->
-                        Expect.equal
-                            (View.Notification.Error
-                                { message = TransferFailed "402"
-                                , detail = "account_missing\nMissing required accounts, repull the identity"
+                            { status = Authenticated
+                            , account = "ACCOUNT"
+                            , authority = "AUTHORITY"
+                            }
+                            (decodeWalletResponse
+                                { status = "WALLET_STATUS_AUTHENTICATED"
+                                , account = "ACCOUNT"
+                                , authority = "AUTHORITY"
                                 }
                             )
-                            (decodePushActionResponse
-                                { response
-                                    | code = 402
-                                    , type_ = "account_missing"
-                                    , message = "Missing required accounts, repull the identity"
+                , test "loaded" <|
+                    \() ->
+                        Expect.equal
+                            { status = Loaded
+                            , account = ""
+                            , authority = ""
+                            }
+                            (decodeWalletResponse
+                                { status = "WALLET_STATUS_LOADED"
+                                , account = ""
+                                , authority = ""
+                                }
+                            )
+                , test "notFound" <|
+                    \() ->
+                        Expect.equal
+                            { status = NotFound
+                            , account = ""
+                            , authority = ""
+                            }
+                            (decodeWalletResponse
+                                { status = "WALLET_STATUS_NOT_FOUND"
+                                , account = ""
+                                , authority = ""
                                 }
                             )
                 ]
             ]
-        , describe "decodeWalletResponse"
-            [ test "authenticated" <|
-                \() ->
-                    Expect.equal
-                        { status = Authenticated
-                        , account = "ACCOUNT"
-                        , authority = "AUTHORITY"
-                        }
-                        (decodeWalletResponse
-                            { status = "WALLET_STATUS_AUTHENTICATED"
-                            , account = "ACCOUNT"
-                            , authority = "AUTHORITY"
-                            }
-                        )
-            , test "loaded" <|
-                \() ->
-                    Expect.equal
-                        { status = Loaded
-                        , account = ""
-                        , authority = ""
-                        }
-                        (decodeWalletResponse
-                            { status = "WALLET_STATUS_LOADED"
-                            , account = ""
-                            , authority = ""
-                            }
-                        )
-            , test "notFound" <|
-                \() ->
-                    Expect.equal
-                        { status = NotFound
-                        , account = ""
-                        , authority = ""
-                        }
-                        (decodeWalletResponse
-                            { status = "WALLET_STATUS_NOT_FOUND"
-                            , account = ""
-                            , authority = ""
-                            }
-                        )
-            ]
-        ]


### PR DESCRIPTION
and modify the notification view to a more universal structure

계정 생성 화면들에서 http 요청을 날리는 경우에 결과를 밸리데이션 뷰에서 보여주면 인식이 잘 안되어서 노티피케이션 뷰를 사용하도록 하였습니다. 추가로 notification 뷰를 범용적으로 사용하기 살짝 아쉬운 부분들을 수정했습니다.