### PR TITLE
Use "sendgrid.net" to send email

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,8 @@ class UsersController < ApiController
 
     UserMailer.email_confirmation(@user).deliver
     render json: { msg: I18n.t('users.create_ok') }, status: :ok
+  rescue Net::SMTPAuthenticationError
+    render json: { msg: I18n.t('users.smtp_authentication_error') }, status: :internal_server_error
   end
 
   def confirm_email

--- a/config/environments/alpha.rb
+++ b/config/environments/alpha.rb
@@ -72,9 +72,8 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address:              'smtp.gmail.com',
+    address:              'smtp.sendgrid.net',
     port:                 587,
-    domain:               'chain.partners',
     user_name:            ENV['EMAIL_USER'],
     password:             ENV['EMAIL_PASS'],
     authentication:       'plain',

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -3,6 +3,7 @@ en:
     create_ok: 'Verification mail sent! Please check your email.'
     already_confirmed_email: 'This email has already been used to create an EOS account.'
     failed_to_create_email_verification_log: 'Failed to create an email verification log'
+    smtp_authentication_error: 'Failed to send a verification email'
     eos_account_already_exist: 'The account already exists in the EOS block chain'
     eos_account_created: "Welcome to the EOS! \"%{account_name}\" has been created."
     eos_account_creation_failure_no_such_email: 'User does not exist with this email'

--- a/config/locales/controllers/ko.yml
+++ b/config/locales/controllers/ko.yml
@@ -3,6 +3,7 @@ ko:
     create_ok: '인증 메일이 전송되었습니다! 이메일을 확인해주세요.'
     already_confirmed_email: 'EOS 계정 생성을 위해 이미 사용된 이메일입니다.'
     failed_to_create_email_verification_log: '시스템에 문제가 있어 이메일 인증 기록을 저장하는데 실패했습니다.'
+    smtp_authentication_error: '시스템에 문제가 있어 이메일 전송에 실패했습니다.'
     eos_account_already_exist: 'EOS 블록체인에 해당 계정이 이미 존재합니다.'
     eos_account_created: "환영합니다! EOS 계정, \"%{account_name}\"이(가) 만들어졌습니다."
     eos_account_creation_failure_no_such_email: '해당 이메일로 생성된 사용자가 없습니다.'

--- a/deploy/alpha/dockerfile
+++ b/deploy/alpha/dockerfile
@@ -10,6 +10,8 @@ ENV RAILS_MAX_THREADS 10
 # Dead connection이 있을 수 있으므로 스레드 개수보다 크게
 ENV DB_POOL 20
 ARG RAILS_MASTER_KEY
+ARG EMAIL_USER
+ARG EMAIL_PASS
 
 # Setting nginx
 COPY deploy/alpha/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
1. 메일 전송시 지메일대신에 sendgrid.net을 사용하도록 수정하였고 (전사적으로 sendgrid.net을 사용하는 것으로 데이빗쪽과 협의하였습니다.)
2. 메일서버 인증에 실패하는 경우 에러처리를 하도록 했습니다.