### PR TITLE
Open nginx acl to all and use aws security group acl

### DIFF
--- a/deploy/alpha/nginx.conf
+++ b/deploy/alpha/nginx.conf
@@ -36,7 +36,8 @@ http {
   }
 
   map $client_ip $allowed {
-    default deny;
+    # default deny;
+    default allow;
 
     # 역삼오피스 ip
     ~\s*59\.9\.219\.9$ allow;


### PR DESCRIPTION
성민님이 외부에서 알파서버 접근할 수 있도록 nginx의 acl은 다 열고 aws security group의 acl에서 ip를 제한적으로 허용하도록 했습니다.