### PR TITLE
Resource/calculate amount

### DIFF
--- a/app/frontend/src/elm/Component/Main/MainComponent.elm
+++ b/app/frontend/src/elm/Component/Main/MainComponent.elm
@@ -59,7 +59,7 @@ import Navigation exposing (Location)
 import Port
 import Route exposing (Route(..), parseLocation)
 import Translation exposing (I18n(..), Language(..), translate)
-import Util.Formatter exposing (eosStringToFloat)
+import Util.Formatter exposing (assetToFloat)
 import Util.Validation exposing (isAccount, isPublicKey)
 import Util.WalletDecoder exposing (PushActionResponse, Wallet, decodePushActionResponse)
 import View.Notification as Notification
@@ -424,7 +424,7 @@ update message ({ page, notification, header, sidebar } as model) =
                         subMessage
                         subModel
                         sidebar.wallet.account
-                        (eosStringToFloat sidebar.account.coreLiquidBalance)
+                        (assetToFloat sidebar.account.coreLiquidBalance)
             in
             ( { model | page = newPage |> TransferPage }, Cmd.map TransferMessage subCmd )
 

--- a/app/frontend/src/elm/Component/Main/Page/Resource.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource.elm
@@ -160,16 +160,16 @@ view language ({ selectedTab, tab, isStakeAmountModalOpened, isDelegateListModal
         tabHtml =
             case tab of
                 Stake stakeModel ->
-                    Html.map StakeMessage (StakeTab.view language StakeTab.initModel account)
+                    Html.map StakeMessage (StakeTab.view language stakeModel account)
 
                 Unstake unstakeModel ->
-                    Html.map UnstakeMessage (UnstakeTab.view language UnstakeTab.initModel account)
+                    Html.map UnstakeMessage (UnstakeTab.view language unstakeModel account)
 
                 Delegate delegateModel ->
-                    Html.map DelegateMessage (DelegateTab.view language DelegateTab.initModel account)
+                    Html.map DelegateMessage (DelegateTab.view language delegateModel account)
 
                 Undelegate undelegateModel ->
-                    Html.map UndelegateMessage (UndelegateTab.view language UndelegateTab.initModel account)
+                    Html.map UndelegateMessage (UndelegateTab.view language undelegateModel account)
     in
     div []
         [ main_ [ class "resource_management" ]

--- a/app/frontend/src/elm/Component/Main/Page/Resource.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource.elm
@@ -1,4 +1,13 @@
-module Component.Main.Page.Resource exposing (Message(..), Model, ResourceTab(..), SelectedTab(..), initModel, resourceTabA, update, view)
+module Component.Main.Page.Resource exposing
+    ( Message(..)
+    , Model
+    , ResourceTab(..)
+    , SelectedTab(..)
+    , initModel
+    , resourceTabA
+    , update
+    , view
+    )
 
 import Component.Main.Page.Resource.Delegate as DelegateTab
 import Component.Main.Page.Resource.Stake as StakeTab

--- a/app/frontend/src/elm/Component/Main/Page/Resource.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource.elm
@@ -1,4 +1,4 @@
-module Component.Main.Page.Resource exposing (Message(..), Model, ResourceTab(..), SelectedTab(..), initModel, resourceTabA, update, view, viewDelegateListModal, viewStakeAmountModal)
+module Component.Main.Page.Resource exposing (Message(..), Model, ResourceTab(..), SelectedTab(..), initModel, resourceTabA, update, view)
 
 import Component.Main.Page.Resource.Delegate as DelegateTab
 import Component.Main.Page.Resource.Stake as StakeTab
@@ -30,8 +30,6 @@ import Translation exposing (I18n(..), Language, translate)
 type alias Model =
     { selectedTab : SelectedTab
     , tab : ResourceTab
-    , isStakeAmountModalOpened : Bool
-    , isDelegateListModalOpened : Bool
     }
 
 
@@ -53,8 +51,6 @@ initModel : Model
 initModel =
     { selectedTab = StakeSelected
     , tab = Stake StakeTab.initModel
-    , isStakeAmountModalOpened = False
-    , isDelegateListModalOpened = False
     }
 
 
@@ -75,19 +71,14 @@ update : Message -> Model -> Account -> ( Model, Cmd Message )
 update message ({ tab } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
     case ( message, tab ) of
         ( StakeMessage stakeMessage, Stake stakeModel ) ->
-            case stakeMessage of
-                StakeTab.OpenStakeAmountModal ->
-                    ( { model | isStakeAmountModalOpened = True }, Cmd.none )
-
-                _ ->
-                    let
-                        ( newModel, _ ) =
-                            StakeTab.update
-                                stakeMessage
-                                stakeModel
-                                account
-                    in
-                    ( { model | tab = Stake newModel }, Cmd.none )
+            let
+                ( newModel, _ ) =
+                    StakeTab.update
+                        stakeMessage
+                        stakeModel
+                        account
+            in
+            ( { model | tab = Stake newModel }, Cmd.none )
 
         ( UnstakeMessage unstakeMessage, Unstake unstakeModel ) ->
             let
@@ -100,34 +91,24 @@ update message ({ tab } as model) ({ totalResources, selfDelegatedBandwidth, cor
             ( { model | tab = Unstake newModel }, Cmd.none )
 
         ( DelegateMessage delegateMessage, Delegate delegateModel ) ->
-            case delegateMessage of
-                DelegateTab.OpenDelegateListModal ->
-                    ( { model | isDelegateListModalOpened = True }, Cmd.none )
-
-                _ ->
-                    let
-                        ( newModel, _ ) =
-                            DelegateTab.update
-                                delegateMessage
-                                delegateModel
-                                account
-                    in
-                    ( { model | tab = Delegate newModel }, Cmd.none )
+            let
+                ( newModel, _ ) =
+                    DelegateTab.update
+                        delegateMessage
+                        delegateModel
+                        account
+            in
+            ( { model | tab = Delegate newModel }, Cmd.none )
 
         ( UndelegateMessage undelegateMessage, Undelegate undelegateModel ) ->
-            case undelegateMessage of
-                UndelegateTab.OpenDelegateListModal ->
-                    ( { model | isDelegateListModalOpened = True }, Cmd.none )
-
-                _ ->
-                    let
-                        ( newModel, _ ) =
-                            UndelegateTab.update
-                                undelegateMessage
-                                undelegateModel
-                                account
-                    in
-                    ( { model | tab = Undelegate newModel }, Cmd.none )
+            let
+                ( newModel, _ ) =
+                    UndelegateTab.update
+                        undelegateMessage
+                        undelegateModel
+                        account
+            in
+            ( { model | tab = Undelegate newModel }, Cmd.none )
 
         ( ChangeTab newTab, _ ) ->
             case newTab of
@@ -143,9 +124,6 @@ update message ({ tab } as model) ({ totalResources, selfDelegatedBandwidth, cor
                 Undelegate undelegateModel ->
                     ( { model | tab = newTab, selectedTab = UndelegateSelected }, Cmd.none )
 
-        ( CloseModal, _ ) ->
-            ( { model | isStakeAmountModalOpened = False, isDelegateListModalOpened = False }, Cmd.none )
-
         ( _, _ ) ->
             ( model, Cmd.none )
 
@@ -155,7 +133,7 @@ update message ({ tab } as model) ({ totalResources, selfDelegatedBandwidth, cor
 
 
 view : Language -> Model -> Account -> Html Message
-view language ({ selectedTab, tab, isStakeAmountModalOpened, isDelegateListModalOpened } as model) account =
+view language ({ selectedTab, tab } as model) account =
     let
         tabHtml =
             case tab of
@@ -185,8 +163,6 @@ view language ({ selectedTab, tab, isStakeAmountModalOpened, isDelegateListModal
                 ]
             , tabHtml
             ]
-        , viewStakeAmountModal isStakeAmountModalOpened
-        , viewDelegateListModal isDelegateListModalOpened
         ]
 
 
@@ -232,142 +208,3 @@ resourceTabA ({ selectedTab } as model) selected =
         , onClick (ChangeTab resourceTab)
         ]
         [ text aText ]
-
-
-viewStakeAmountModal : Bool -> Html Message
-viewStakeAmountModal opened =
-    section
-        [ attribute "aria-live" "true"
-        , class
-            ("set_division_manual modal popup"
-                ++ (if opened then
-                        " viewing"
-
-                    else
-                        ""
-                   )
-            )
-        , id "popup"
-        , attribute "role" "alert"
-        ]
-        [ div [ class "wrapper" ]
-            [ h2 []
-                [ text "토큰 스테이크 수량 직접 설정" ]
-            , div [ class "token status" ]
-                [ h3 []
-                    [ text "스테이크할 토큰"
-                    , strong []
-                        [ text "10 EOS" ]
-                    ]
-                , button [ class "set auto button", type_ "button" ]
-                    [ text "자동 분배" ]
-                ]
-            , div [ class "form container" ]
-                [ h3 []
-                    [ text "CPU" ]
-                , p []
-                    [ text "Staked : 18 EOS" ]
-                , Html.form [ action "", class "true validate" ]
-                    [ input [ class "user", attribute "data-validate" "false", id "", name "", placeholder "스테이크할 수량을 설정하세요", type_ "text" ]
-                        []
-                    , span []
-                        [ text "EOS" ]
-                    ]
-                ]
-            , div [ class "form container" ]
-                [ h3 []
-                    [ text "NET" ]
-                , p []
-                    [ text "Staked : 18 EOS" ]
-                , Html.form [ action "" ]
-                    [ input [ class "user", attribute "data-validate" "true", id "", name "", placeholder "스테이크할 수량을 설정하세요", type_ "text" ]
-                        []
-                    , span []
-                        [ text "EOS" ]
-                    ]
-                ]
-            , p [ class "validate description" ]
-                [ text "7:3 비율로 스테이킹 하는 것이 가장 좋습니다." ]
-            , div [ class "btn_area" ]
-                [ button [ class "undo button", type_ "button", onClick CloseModal ]
-                    [ text "취소" ]
-                , button [ class "ok button", attribute "disabled" "", type_ "button" ]
-                    [ text "확인" ]
-                ]
-            ]
-        ]
-
-
-viewDelegateListModal : Bool -> Html Message
-viewDelegateListModal opened =
-    section
-        [ attribute "aria-live" "true"
-        , class
-            ("rental_account modal popup"
-                ++ (if opened then
-                        " viewing"
-
-                    else
-                        ""
-                   )
-            )
-        , id "popup"
-        , attribute "role" "alert"
-        ]
-        [ div [ class "wrapper" ]
-            [ h2 []
-                [ text "임대해준 계정 리스트" ]
-            , Html.form [ action "" ]
-                [ input [ class "search_token", id "", name "", placeholder "계정명 검색하기", type_ "text" ]
-                    []
-                , button [ type_ "button" ]
-                    [ text "검색" ]
-                ]
-            , div [ class "result list", attribute "role" "listbox" ]
-                [ ul []
-                    [ li []
-                        [ h3 []
-                            [ text "blockoine123" ]
-                        , p []
-                            [ text "CPU : 123123123 EOS" ]
-                        , p []
-                            [ text "NET : 123123123 EOS" ]
-                        , button [ type_ "button" ]
-                            [ text "취소하기" ]
-                        ]
-                    , li []
-                        [ h3 []
-                            [ text "blockoine123" ]
-                        , p []
-                            [ text "CPU : 123123123 EOS" ]
-                        , p []
-                            [ text "NET : 123123123 EOS" ]
-                        , button [ type_ "button" ]
-                            [ text "취소하기" ]
-                        ]
-                    , li []
-                        [ h3 []
-                            [ text "blockoine123" ]
-                        , p []
-                            [ text "CPU : 123123123 EOS" ]
-                        , p []
-                            [ text "NET : 123123123 EOS" ]
-                        , button [ type_ "button" ]
-                            [ text "취소하기" ]
-                        ]
-                    , li []
-                        [ h3 []
-                            [ text "blockoine123" ]
-                        , p []
-                            [ text "CPU : 123123123 EOS" ]
-                        , p []
-                            [ text "NET : 123123123 EOS" ]
-                        , button [ type_ "button" ]
-                            [ text "취소하기" ]
-                        ]
-                    ]
-                ]
-            , button [ class "close", id "closePopup", type_ "button", onClick CloseModal ]
-                [ text "닫기" ]
-            ]
-        ]

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Delegate.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Delegate.elm
@@ -1,4 +1,4 @@
-module Component.Main.Page.Resource.Delegate exposing (Message(..), Modal(..), Model, initModel, update, view)
+module Component.Main.Page.Resource.Delegate exposing (Message(..), Model, initModel, update, view)
 
 import Component.Main.Page.Resource.Modal.DelegateList as DelegateList
     exposing
@@ -30,18 +30,14 @@ import Translation exposing (I18n(..), Language, translate)
 
 type alias Model =
     { delegateInput : String
-    , modal : Modal
+    , modal : DelegateList.Model
     }
-
-
-type Modal
-    = DelegateListModal DelegateList.Model
 
 
 initModel : Model
 initModel =
     { delegateInput = ""
-    , modal = DelegateListModal DelegateList.initModel
+    , modal = DelegateList.initModel
     }
 
 
@@ -57,29 +53,26 @@ type Message
 
 update : Message -> Model -> Account -> ( Model, Cmd Message )
 update message ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
-    case ( message, modal ) of
-        ( InputDelegateAmount value, _ ) ->
+    case message of
+        InputDelegateAmount value ->
             ( { model | delegateInput = value }, Cmd.none )
 
-        ( OpenDelegateListModal, _ ) ->
-            case modal of
-                DelegateListModal modalModel ->
-                    ( { model
-                        | modal =
-                            DelegateListModal
-                                { modalModel
-                                    | isDelegateListModalOpened = True
-                                }
-                      }
-                    , Cmd.none
-                    )
+        OpenDelegateListModal ->
+            ( { model
+                | modal =
+                    { modal
+                        | isDelegateListModalOpened = True
+                    }
+              }
+            , Cmd.none
+            )
 
-        ( DelegateListMessage subMessage, DelegateListModal subModel ) ->
+        DelegateListMessage subMessage ->
             let
                 ( newModel, _ ) =
-                    DelegateList.update subMessage subModel
+                    DelegateList.update subMessage modal
             in
-            ( { model | modal = DelegateListModal newModel }, Cmd.none )
+            ( { model | modal = newModel }, Cmd.none )
 
 
 
@@ -90,9 +83,7 @@ view : Language -> Model -> Account -> Html Message
 view language ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
     let
         modalHtml =
-            case modal of
-                DelegateListModal subModel ->
-                    Html.map DelegateListMessage (viewDelegateListModal language subModel)
+            Html.map DelegateListMessage (viewDelegateListModal language modal)
     in
     div [ class "rental cancel container" ]
         [ div [ class "available status" ]

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Delegate.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Delegate.elm
@@ -30,14 +30,14 @@ import Translation exposing (I18n(..), Language, translate)
 
 type alias Model =
     { delegateInput : String
-    , modal : DelegateList.Model
+    , delegateListModal : DelegateList.Model
     }
 
 
 initModel : Model
 initModel =
     { delegateInput = ""
-    , modal = DelegateList.initModel
+    , delegateListModal = DelegateList.initModel
     }
 
 
@@ -52,15 +52,15 @@ type Message
 
 
 update : Message -> Model -> Account -> ( Model, Cmd Message )
-update message ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
+update message ({ delegateListModal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
     case message of
         InputDelegateAmount value ->
             ( { model | delegateInput = value }, Cmd.none )
 
         OpenDelegateListModal ->
             ( { model
-                | modal =
-                    { modal
+                | delegateListModal =
+                    { delegateListModal
                         | isDelegateListModalOpened = True
                     }
               }
@@ -70,9 +70,9 @@ update message ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, c
         DelegateListMessage subMessage ->
             let
                 ( newModel, _ ) =
-                    DelegateList.update subMessage modal
+                    DelegateList.update subMessage delegateListModal
             in
-            ( { model | modal = newModel }, Cmd.none )
+            ( { model | delegateListModal = newModel }, Cmd.none )
 
 
 
@@ -80,10 +80,10 @@ update message ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, c
 
 
 view : Language -> Model -> Account -> Html Message
-view language ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
+view language ({ delegateListModal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
     let
         modalHtml =
-            Html.map DelegateListMessage (viewDelegateListModal language modal)
+            Html.map DelegateListMessage (viewDelegateListModal language delegateListModal)
     in
     div [ class "rental cancel container" ]
         [ div [ class "available status" ]

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Modal/DelegateList.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Modal/DelegateList.elm
@@ -1,4 +1,10 @@
-module Component.Main.Page.Resource.Modal.DelegateList exposing (Message(..), Model, initModel, update, viewDelegateListModal)
+module Component.Main.Page.Resource.Modal.DelegateList exposing
+    ( Message(..)
+    , Model
+    , initModel
+    , update
+    , viewDelegateListModal
+    )
 
 import Html exposing (..)
 import Html.Attributes exposing (..)

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Modal/DelegateList.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Modal/DelegateList.elm
@@ -1,0 +1,119 @@
+module Component.Main.Page.Resource.Modal.DelegateList exposing (Message(..), Model, initModel, update, viewDelegateListModal)
+
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Translation exposing (I18n(..), Language, translate)
+
+
+
+-- MODEL
+
+
+type alias Model =
+    { cpuInput : String
+    , netInput : String
+    , isDelegateListModalOpened : Bool
+    }
+
+
+initModel : Model
+initModel =
+    { cpuInput = ""
+    , netInput = ""
+    , isDelegateListModalOpened = False
+    }
+
+
+
+-- UPDATE
+
+
+type Message
+    = CloseModal
+
+
+update : Message -> Model -> ( Model, Cmd Message )
+update message model =
+    case message of
+        CloseModal ->
+            ( { model | isDelegateListModalOpened = False }, Cmd.none )
+
+
+
+-- VIEW
+
+
+viewDelegateListModal : Language -> Model -> Html Message
+viewDelegateListModal language ({ isDelegateListModalOpened } as model) =
+    section
+        [ attribute "aria-live" "true"
+        , class
+            ("rental_account modal popup"
+                ++ (if isDelegateListModalOpened then
+                        " viewing"
+
+                    else
+                        ""
+                   )
+            )
+        , id "popup"
+        , attribute "role" "alert"
+        ]
+        [ div [ class "wrapper" ]
+            [ h2 []
+                [ text "임대해준 계정 리스트" ]
+            , Html.form [ action "" ]
+                [ input [ class "search_token", id "", name "", placeholder "계정명 검색하기", type_ "text" ]
+                    []
+                , button [ type_ "button" ]
+                    [ text "검색" ]
+                ]
+            , div [ class "result list", attribute "role" "listbox" ]
+                [ ul []
+                    [ li []
+                        [ h3 []
+                            [ text "blockoine123" ]
+                        , p []
+                            [ text "CPU : 123123123 EOS" ]
+                        , p []
+                            [ text "NET : 123123123 EOS" ]
+                        , button [ type_ "button" ]
+                            [ text "취소하기" ]
+                        ]
+                    , li []
+                        [ h3 []
+                            [ text "blockoine123" ]
+                        , p []
+                            [ text "CPU : 123123123 EOS" ]
+                        , p []
+                            [ text "NET : 123123123 EOS" ]
+                        , button [ type_ "button" ]
+                            [ text "취소하기" ]
+                        ]
+                    , li []
+                        [ h3 []
+                            [ text "blockoine123" ]
+                        , p []
+                            [ text "CPU : 123123123 EOS" ]
+                        , p []
+                            [ text "NET : 123123123 EOS" ]
+                        , button [ type_ "button" ]
+                            [ text "취소하기" ]
+                        ]
+                    , li []
+                        [ h3 []
+                            [ text "blockoine123" ]
+                        , p []
+                            [ text "CPU : 123123123 EOS" ]
+                        , p []
+                            [ text "NET : 123123123 EOS" ]
+                        , button [ type_ "button" ]
+                            [ text "취소하기" ]
+                        ]
+                    ]
+                ]
+            , button [ class "close", id "closePopup", type_ "button", onClick CloseModal ]
+                [ text "닫기" ]
+            ]
+        ]

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Stake.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Stake.elm
@@ -55,7 +55,7 @@ type alias Model =
     , totalQuantityValidation : QuantityStatus
     , cpuQuantityValidation : QuantityStatus
     , netQuantityValidation : QuantityStatus
-    , isManual : Bool
+    , manuallySet : Bool
     , isFormValid : Bool
     , isStakeAmountModalOpened : Bool
     , stakeAmountModal : StakeAmountModal
@@ -96,7 +96,7 @@ initModel =
     , totalQuantityValidation = EmptyQuantity
     , cpuQuantityValidation = EmptyQuantity
     , netQuantityValidation = EmptyQuantity
-    , isManual = False
+    , manuallySet = False
     , isFormValid = False
     , isStakeAmountModalOpened = False
     , stakeAmountModal =
@@ -140,16 +140,16 @@ update message ({ delegatebw, totalQuantity, distributionRatio, stakeAmountModal
                 ( cpuQuantity, netQuantity ) =
                     distributeCpuNet value distributionRatio.cpu distributionRatio.net
 
-                toBeValidatedModel =
+                newModel =
                     { model
                         | totalQuantity = value
                         , delegatebw =
                             { delegatebw | stakeCpuQuantity = cpuQuantity, stakeNetQuantity = netQuantity }
                         , percentageOfLiquid = NoOp
-                        , isManual = False
+                        , manuallySet = False
                     }
             in
-            ( validate toBeValidatedModel (eosStringToFloat coreLiquidBalance) isStakeAmountModalOpened
+            ( validate newModel (eosStringToFloat coreLiquidBalance) isStakeAmountModalOpened
             , Cmd.none
             )
 
@@ -171,7 +171,7 @@ update message ({ delegatebw, totalQuantity, distributionRatio, stakeAmountModal
                 , delegatebw =
                     { delegatebw | stakeCpuQuantity = cpuQuantity, stakeNetQuantity = netQuantity }
                 , percentageOfLiquid = percentageOfLiquid
-                , isManual = False
+                , manuallySet = False
               }
             , Cmd.none
             )
@@ -188,7 +188,7 @@ update message ({ delegatebw, totalQuantity, distributionRatio, stakeAmountModal
                                 |> eosStringToFloat
                                 |> toString
 
-                        toBeValidatedModel =
+                        newModel =
                             { model
                                 | stakeAmountModal =
                                     { stakeAmountModal
@@ -197,7 +197,7 @@ update message ({ delegatebw, totalQuantity, distributionRatio, stakeAmountModal
                                     }
                             }
                     in
-                    ( validate toBeValidatedModel (eosStringToFloat coreLiquidBalance) isStakeAmountModalOpened, Cmd.none )
+                    ( validate newModel (eosStringToFloat coreLiquidBalance) isStakeAmountModalOpened, Cmd.none )
 
                 NetAmountInput value ->
                     let
@@ -206,7 +206,7 @@ update message ({ delegatebw, totalQuantity, distributionRatio, stakeAmountModal
                                 |> eosStringToFloat
                                 |> toString
 
-                        toBeValidatedModel =
+                        newModel =
                             { model
                                 | stakeAmountModal =
                                     { stakeAmountModal
@@ -215,7 +215,7 @@ update message ({ delegatebw, totalQuantity, distributionRatio, stakeAmountModal
                                     }
                             }
                     in
-                    ( validate toBeValidatedModel (eosStringToFloat coreLiquidBalance) isStakeAmountModalOpened, Cmd.none )
+                    ( validate newModel (eosStringToFloat coreLiquidBalance) isStakeAmountModalOpened, Cmd.none )
 
                 CloseModal ->
                     ( { model | isStakeAmountModalOpened = False }, Cmd.none )
@@ -468,11 +468,11 @@ getPercentageOfLiquid percentageOfLiquid =
 
 
 quantityWarningSpan : QuantityStatus -> Language -> Model -> Html Message
-quantityWarningSpan quantityStatus language ({ delegatebw, isManual } as model) =
+quantityWarningSpan quantityStatus language ({ delegatebw, manuallySet } as model) =
     let
         -- TODO(boseok): it needs to be translated
         manualText =
-            if isManual then
+            if manuallySet then
                 "직접설정"
 
             else

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Stake.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Stake.elm
@@ -17,8 +17,9 @@ import Data.Action as Action exposing (DelegatebwParameters, encodeAction)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput)
+import Round
 import Translation exposing (I18n(..), Language, translate)
-import Util.Formatter exposing (eosFloatToString, eosStringAdd, eosStringSubtract, larimerToEos)
+import Util.Formatter exposing (eosFloatToString, eosStringAdd, eosStringSubtract, eosStringToFloat, larimerToEos)
 import Util.Validation as Validation
     exposing
         ( AccountStatus(..)
@@ -37,6 +38,7 @@ import Util.Validation as Validation
 type alias Model =
     { delegatebw : DelegatebwParameters
     , totalQuantity : String
+    , percentageOfLiquid : PercentageOfLiquid
     , totalQuantityValidation : QuantityStatus
     , cpuQuantityValidation : QuantityStatus
     , netQuantityValidation : QuantityStatus
@@ -44,10 +46,19 @@ type alias Model =
     }
 
 
+type PercentageOfLiquid
+    = NoOp
+    | Percentage10
+    | Percentage50
+    | Percentage70
+    | Percentage100
+
+
 initModel : Model
 initModel =
     { delegatebw = { from = "", receiver = "", stakeNetQuantity = "", stakeCpuQuantity = "", transfer = 1 }
     , totalQuantity = ""
+    , percentageOfLiquid = NoOp
     , totalQuantityValidation = EmptyQuantity
     , cpuQuantityValidation = EmptyQuantity
     , netQuantityValidation = EmptyQuantity
@@ -66,17 +77,61 @@ type Message
 
 
 update : Message -> Model -> Account -> ( Model, Cmd Message )
-update message model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
+update message ({ delegatebw, totalQuantity } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
     let
         stakeAbleAmount =
             coreLiquidBalance
     in
     case message of
         TotalAmountInput value ->
-            ( { model | totalQuantity = value }, Cmd.none )
+            let
+                ( cpuQuantity, netQuantity ) =
+                    distributeCpuNet value 7 3
+            in
+            ( { model
+                | totalQuantity = value
+                , delegatebw =
+                    { delegatebw | stakeCpuQuantity = cpuQuantity, stakeNetQuantity = netQuantity }
+                , percentageOfLiquid = NoOp
+              }
+            , Cmd.none
+            )
 
-        StakePercentage percentage ->
-            ( model, Cmd.none )
+        StakePercentage ratio ->
+            let
+                value =
+                    eosStringToFloat coreLiquidBalance
+                        * ratio
+                        |> Round.round 4
+
+                percentageOfLiquid =
+                    case ratio of
+                        0.1 ->
+                            Percentage10
+
+                        0.5 ->
+                            Percentage50
+
+                        0.7 ->
+                            Percentage70
+
+                        1 ->
+                            Percentage100
+
+                        _ ->
+                            NoOp
+
+                ( cpuQuantity, netQuantity ) =
+                    distributeCpuNet value 7 3
+            in
+            ( { model
+                | totalQuantity = value
+                , delegatebw =
+                    { delegatebw | stakeCpuQuantity = cpuQuantity, stakeNetQuantity = netQuantity }
+                , percentageOfLiquid = percentageOfLiquid
+              }
+            , Cmd.none
+            )
 
         _ ->
             ( model, Cmd.none )
@@ -87,7 +142,7 @@ update message model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalanc
 
 
 view : Language -> Model -> Account -> Html Message
-view language model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
+view language ({ delegatebw, totalQuantity } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
     let
         stakedAmount =
             eosFloatToString (larimerToEos account.voterInfo.staked)
@@ -177,17 +232,13 @@ view language model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance
 
                 -- TODO(boseok): this should be applied to new design
                 , p [ class "validate description" ]
-                    [ text "cpu" ]
+                    [ text ("cpu : " ++ delegatebw.stakeCpuQuantity) ]
                 , p [ class "validate description" ]
-                    [ text "net" ]
-                , button [ type_ "button", onClick (StakePercentage 0.1) ]
-                    [ text "10%" ]
-                , button [ type_ "button", onClick (StakePercentage 0.5) ]
-                    [ text "50%" ]
-                , button [ type_ "button", onClick (StakePercentage 0.7) ]
-                    [ text "70%" ]
-                , button [ type_ "button", onClick (StakePercentage 1) ]
-                    [ text "최대" ]
+                    [ text ("net : " ++ delegatebw.stakeNetQuantity) ]
+                , percentageButton 0.1
+                , percentageButton 0.5
+                , percentageButton 0.7
+                , percentageButton 1
                 ]
             , div [ class "btn_area" ]
                 [ button [ class "ok button", attribute "disabled" "", type_ "button" ]
@@ -195,6 +246,20 @@ view language model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance
                 ]
             ]
         ]
+
+
+percentageButton : Float -> Html Message
+percentageButton ratio =
+    let
+        buttonText =
+            if ratio < 1 then
+                Round.round 0 (ratio * 100) ++ "%"
+
+            else
+                "최대"
+    in
+    button [ type_ "button", onClick (StakePercentage ratio) ]
+        [ text buttonText ]
 
 
 quantityWarningSpan : QuantityStatus -> Language -> Html Message
@@ -246,3 +311,15 @@ validate ({ delegatebw } as model) eosLiquidAmount =
         , netQuantityValidation = netQuantityValidation
         , isFormValid = isFormValid
     }
+
+
+distributeCpuNet : String -> Float -> Float -> ( String, String )
+distributeCpuNet totalQuantity a b =
+    let
+        cpuQuantity =
+            eosFloatToString <| eosStringToFloat totalQuantity * (a / (a + b))
+
+        netQuantity =
+            eosStringSubtract totalQuantity cpuQuantity
+    in
+    ( cpuQuantity, netQuantity )

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Undelegate.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Undelegate.elm
@@ -1,5 +1,10 @@
-module Component.Main.Page.Resource.Undelegate exposing (Message(..), Model, initModel, update, view)
+module Component.Main.Page.Resource.Undelegate exposing (Message(..), Modal(..), Model, initModel, update, view)
 
+import Component.Main.Page.Resource.Modal.DelegateList as DelegateList
+    exposing
+        ( Message(..)
+        , viewDelegateListModal
+        )
 import Data.Account
     exposing
         ( Account
@@ -25,12 +30,19 @@ import Translation exposing (I18n(..), Language, translate)
 
 type alias Model =
     { undelegateInput : String
+    , modal : Modal
     }
+
+
+type Modal
+    = DelegateListModal DelegateList.Model
 
 
 initModel : Model
 initModel =
-    { undelegateInput = "" }
+    { undelegateInput = ""
+    , modal = DelegateListModal DelegateList.initModel
+    }
 
 
 
@@ -39,17 +51,35 @@ initModel =
 
 type Message
     = InputUndelegateAmount String
-    | OpenDelegateListModal -- This is controlled at Resource module
+    | OpenDelegateListModal
+    | DelegateListMessage DelegateList.Message
 
 
 update : Message -> Model -> Account -> ( Model, Cmd Message )
-update message model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
-    case message of
-        InputUndelegateAmount value ->
+update message ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
+    case ( message, modal ) of
+        ( InputUndelegateAmount value, _ ) ->
             ( { model | undelegateInput = value }, Cmd.none )
 
-        _ ->
-            ( model, Cmd.none )
+        ( OpenDelegateListModal, _ ) ->
+            case modal of
+                DelegateListModal modalModel ->
+                    ( { model
+                        | modal =
+                            DelegateListModal
+                                { modalModel
+                                    | isDelegateListModalOpened = True
+                                }
+                      }
+                    , Cmd.none
+                    )
+
+        ( DelegateListMessage subMessage, DelegateListModal subModel ) ->
+            let
+                ( newModel, _ ) =
+                    DelegateList.update subMessage subModel
+            in
+            ( { model | modal = DelegateListModal newModel }, Cmd.none )
 
 
 
@@ -57,7 +87,13 @@ update message model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalanc
 
 
 view : Language -> Model -> Account -> Html Message
-view language model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
+view language ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
+    let
+        modalHtml =
+            case modal of
+                DelegateListModal subModel ->
+                    Html.map DelegateListMessage (viewDelegateListModal language subModel)
+    in
     div [ class "rental cancel container" ]
         [ div [ class "available status" ]
             [ h3 []
@@ -120,4 +156,5 @@ view language model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance
                     [ text "확인" ]
                 ]
             ]
+        , modalHtml
         ]

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Undelegate.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Undelegate.elm
@@ -1,4 +1,4 @@
-module Component.Main.Page.Resource.Undelegate exposing (Message(..), Modal(..), Model, initModel, update, view)
+module Component.Main.Page.Resource.Undelegate exposing (Message(..), Model, initModel, update, view)
 
 import Component.Main.Page.Resource.Modal.DelegateList as DelegateList
     exposing
@@ -30,18 +30,14 @@ import Translation exposing (I18n(..), Language, translate)
 
 type alias Model =
     { undelegateInput : String
-    , modal : Modal
+    , modal : DelegateList.Model
     }
-
-
-type Modal
-    = DelegateListModal DelegateList.Model
 
 
 initModel : Model
 initModel =
     { undelegateInput = ""
-    , modal = DelegateListModal DelegateList.initModel
+    , modal = DelegateList.initModel
     }
 
 
@@ -57,29 +53,26 @@ type Message
 
 update : Message -> Model -> Account -> ( Model, Cmd Message )
 update message ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
-    case ( message, modal ) of
-        ( InputUndelegateAmount value, _ ) ->
+    case message of
+        InputUndelegateAmount value ->
             ( { model | undelegateInput = value }, Cmd.none )
 
-        ( OpenDelegateListModal, _ ) ->
-            case modal of
-                DelegateListModal modalModel ->
-                    ( { model
-                        | modal =
-                            DelegateListModal
-                                { modalModel
-                                    | isDelegateListModalOpened = True
-                                }
-                      }
-                    , Cmd.none
-                    )
+        OpenDelegateListModal ->
+            ( { model
+                | modal =
+                    { modal
+                        | isDelegateListModalOpened = True
+                    }
+              }
+            , Cmd.none
+            )
 
-        ( DelegateListMessage subMessage, DelegateListModal subModel ) ->
+        DelegateListMessage subMessage ->
             let
                 ( newModel, _ ) =
-                    DelegateList.update subMessage subModel
+                    DelegateList.update subMessage modal
             in
-            ( { model | modal = DelegateListModal newModel }, Cmd.none )
+            ( { model | modal = newModel }, Cmd.none )
 
 
 
@@ -90,9 +83,7 @@ view : Language -> Model -> Account -> Html Message
 view language ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
     let
         modalHtml =
-            case modal of
-                DelegateListModal subModel ->
-                    Html.map DelegateListMessage (viewDelegateListModal language subModel)
+            Html.map DelegateListMessage (viewDelegateListModal language modal)
     in
     div [ class "rental cancel container" ]
         [ div [ class "available status" ]

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Undelegate.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Undelegate.elm
@@ -30,14 +30,14 @@ import Translation exposing (I18n(..), Language, translate)
 
 type alias Model =
     { undelegateInput : String
-    , modal : DelegateList.Model
+    , delegateListModal : DelegateList.Model
     }
 
 
 initModel : Model
 initModel =
     { undelegateInput = ""
-    , modal = DelegateList.initModel
+    , delegateListModal = DelegateList.initModel
     }
 
 
@@ -52,15 +52,15 @@ type Message
 
 
 update : Message -> Model -> Account -> ( Model, Cmd Message )
-update message ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
+update message ({ delegateListModal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
     case message of
         InputUndelegateAmount value ->
             ( { model | undelegateInput = value }, Cmd.none )
 
         OpenDelegateListModal ->
             ( { model
-                | modal =
-                    { modal
+                | delegateListModal =
+                    { delegateListModal
                         | isDelegateListModalOpened = True
                     }
               }
@@ -70,9 +70,9 @@ update message ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, c
         DelegateListMessage subMessage ->
             let
                 ( newModel, _ ) =
-                    DelegateList.update subMessage modal
+                    DelegateList.update subMessage delegateListModal
             in
-            ( { model | modal = newModel }, Cmd.none )
+            ( { model | delegateListModal = newModel }, Cmd.none )
 
 
 
@@ -80,10 +80,10 @@ update message ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, c
 
 
 view : Language -> Model -> Account -> Html Message
-view language ({ modal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
+view language ({ delegateListModal } as model) ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance } as account) =
     let
         modalHtml =
-            Html.map DelegateListMessage (viewDelegateListModal language modal)
+            Html.map DelegateListMessage (viewDelegateListModal language delegateListModal)
     in
     div [ class "rental cancel container" ]
         [ div [ class "available status" ]

--- a/app/frontend/src/elm/Component/Main/Page/Resource/Unstake.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Unstake.elm
@@ -16,7 +16,7 @@ import Data.Account
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Translation exposing (I18n(..), Language, translate)
-import Util.Formatter exposing (eosStringAdd, eosStringSubtract)
+import Util.Formatter exposing (assetAdd, assetSubtract)
 
 
 
@@ -65,7 +65,7 @@ view language model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance
                 , p []
                     [ text ("내가 스테이크한 토큰 : " ++ selfDelegatedBandwidth.cpuWeight) ]
                 , p []
-                    [ text ("임대받은 토큰 : " ++ eosStringSubtract totalResources.cpuWeight selfDelegatedBandwidth.cpuWeight) ]
+                    [ text ("임대받은 토큰 : " ++ assetSubtract totalResources.cpuWeight selfDelegatedBandwidth.cpuWeight) ]
                 , div [ class "graph status" ]
                     [ span [ class "hell", attribute "style" "height:10%" ]
                         []
@@ -81,7 +81,7 @@ view language model ({ totalResources, selfDelegatedBandwidth, coreLiquidBalance
                 , p []
                     [ text ("내가 스테이크한 토큰 : " ++ selfDelegatedBandwidth.netWeight) ]
                 , p []
-                    [ text ("임대받은 토큰 : " ++ eosStringSubtract totalResources.netWeight selfDelegatedBandwidth.netWeight) ]
+                    [ text ("임대받은 토큰 : " ++ assetSubtract totalResources.netWeight selfDelegatedBandwidth.netWeight) ]
                 , div [ class "graph status" ]
                     [ span [ class "hell", attribute "style" "height:10%" ]
                         []

--- a/app/frontend/src/elm/Component/Main/Page/Search.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Search.elm
@@ -67,7 +67,7 @@ import Json.Encode as Encode
 import Translation exposing (I18n(..), Language, translate)
 import Util.Formatter
     exposing
-        ( eosFloatToString
+        ( floatToAsset
         , larimerToEos
         , timeFormatter
         )
@@ -245,7 +245,7 @@ view language { account, actions, selectedActionCategory, openedActionSeq } =
             getUnstakingAmount account.refundRequest.netAmount account.refundRequest.cpuAmount
 
         stakedAmount =
-            eosFloatToString (larimerToEos account.voterInfo.staked)
+            floatToAsset (larimerToEos account.voterInfo.staked)
 
         ( cpuUsed, cpuAvailable, cpuTotal, cpuPercent, cpuColor ) =
             getResource "cpu" account.cpuLimit.used account.cpuLimit.available account.cpuLimit.max

--- a/app/frontend/src/elm/Component/Main/Sidebar.elm
+++ b/app/frontend/src/elm/Component/Main/Sidebar.elm
@@ -1,4 +1,18 @@
-module Component.Main.Sidebar exposing (Message(..), Model, State(..), accountInfoView, deleteFromBack, initCmd, initModel, loadingView, pairWalletView, signInView, subscriptions, update, view)
+module Component.Main.Sidebar exposing
+    ( Message(..)
+    , Model
+    , State(..)
+    , accountInfoView
+    , deleteFromBack
+    , initCmd
+    , initModel
+    , loadingView
+    , pairWalletView
+    , signInView
+    , subscriptions
+    , update
+    , view
+    )
 
 import Data.Account
     exposing

--- a/app/frontend/src/elm/Component/Main/Sidebar.elm
+++ b/app/frontend/src/elm/Component/Main/Sidebar.elm
@@ -32,7 +32,7 @@ import Port
 import Translation exposing (I18n(..), Language(..), toLocale, translate)
 import Util.Formatter
     exposing
-        ( eosFloatToString
+        ( floatToAsset
         , larimerToEos
         )
 import Util.HttpRequest exposing (getFullPath, post)
@@ -215,7 +215,7 @@ accountInfoView { wallet, account, configPanelOpen } language =
             getUnstakingAmount refundRequest.netAmount refundRequest.cpuAmount
 
         stakedAmount =
-            eosFloatToString (larimerToEos voterInfo.staked)
+            floatToAsset (larimerToEos voterInfo.staked)
 
         configPanelClass =
             class

--- a/app/frontend/src/elm/Data/Account.elm
+++ b/app/frontend/src/elm/Data/Account.elm
@@ -19,8 +19,8 @@ import Json.Decode.Pipeline exposing (decode, optional, required)
 import Round
 import Util.Formatter
     exposing
-        ( eosFloatToString
-        , eosStringToFloat
+        ( floatToAsset
+        , assetToFloat
         , larimerToEos
         , percentageConverter
         , resourceUnitConverter
@@ -182,10 +182,10 @@ integerStringDecoder =
 
 getTotalAmount : String -> Int -> String -> String -> String
 getTotalAmount coreLiquidBalance staked unstakingNetAmount unstakingCpuAmount =
-    (eosStringToFloat coreLiquidBalance
+    (assetToFloat coreLiquidBalance
         + larimerToEos staked
-        + eosStringToFloat unstakingNetAmount
-        + eosStringToFloat unstakingCpuAmount
+        + assetToFloat unstakingNetAmount
+        + assetToFloat unstakingCpuAmount
         |> Round.round 4
     )
         ++ " EOS"
@@ -193,7 +193,7 @@ getTotalAmount coreLiquidBalance staked unstakingNetAmount unstakingCpuAmount =
 
 getUnstakingAmount : String -> String -> String
 getUnstakingAmount unstakingNetAmount unstakingCpuAmount =
-    eosFloatToString (eosStringToFloat unstakingNetAmount + eosStringToFloat unstakingCpuAmount)
+    floatToAsset (assetToFloat unstakingNetAmount + assetToFloat unstakingCpuAmount)
 
 
 getResource : String -> Int -> Int -> Int -> ( String, String, String, String, String )

--- a/app/frontend/src/elm/Translation.elm
+++ b/app/frontend/src/elm/Translation.elm
@@ -156,6 +156,9 @@ type I18n
     | ShowMore
     | SearchPublicKey
     | SearchResultPublicKey
+    | StakeAble String String
+    | StakeAbleAmountDesc
+    | OverStakeAbleAmount
 
 
 translate : Language -> I18n -> String
@@ -811,4 +814,22 @@ getMessages i18n =
             { korean = "검색하신 공개 키에 대한 정보입니다 :)"
             , english = "Search result of the public key"
             , chinese = "如下为查询到的公匙信息"
+            }
+
+        StakeAble cpu net ->
+            { korean = "한 CPU " ++ cpu ++ ", NET " ++ net ++ " 스테이크 됩니다."
+            , english = "한 CPU " ++ cpu ++ ", NET " ++ net ++ " 스테이크 됩니다."
+            , chinese = "한 CPU " ++ cpu ++ ", NET " ++ net ++ " 스테이크 됩니다."
+            }
+
+        StakeAbleAmountDesc ->
+            { korean = "보유한 수량만큼 스테이크 할 수 있습니다."
+            , english = ""
+            , chinese = ""
+            }
+
+        OverStakeAbleAmount ->
+            { korean = "스테이크 가능한 수량보다 많습니다."
+            , english = ""
+            , chinese = ""
             }

--- a/app/frontend/src/elm/Util/Formatter.elm
+++ b/app/frontend/src/elm/Util/Formatter.elm
@@ -1,8 +1,8 @@
 module Util.Formatter exposing
-    ( eosFloatToString
-    , eosStringAdd
-    , eosStringSubtract
-    , eosStringToFloat
+    ( assetAdd
+    , assetSubtract
+    , assetToFloat
+    , floatToAsset
     , formatEosQuantity
     , larimerToEos
     , percentageConverter
@@ -23,13 +23,13 @@ larimerToEos valInt =
     toFloat valInt * 0.0001
 
 
-eosFloatToString : Float -> String
-eosFloatToString valFloat =
+floatToAsset : Float -> String
+floatToAsset valFloat =
     Round.round 4 valFloat ++ " EOS"
 
 
-eosStringToFloat : String -> Float
-eosStringToFloat str =
+assetToFloat : String -> Float
+assetToFloat str =
     let
         result =
             str
@@ -44,18 +44,18 @@ eosStringToFloat str =
             0
 
 
-eosStringAdd : String -> String -> String
-eosStringAdd a b =
-    (+) (eosStringToFloat a)
-        (eosStringToFloat b)
-        |> eosFloatToString
+assetAdd : String -> String -> String
+assetAdd a b =
+    (+) (assetToFloat a)
+        (assetToFloat b)
+        |> floatToAsset
 
 
-eosStringSubtract : String -> String -> String
-eosStringSubtract a b =
-    (-) (eosStringToFloat a)
-        (eosStringToFloat b)
-        |> eosFloatToString
+assetSubtract : String -> String -> String
+assetSubtract a b =
+    (-) (assetToFloat a)
+        (assetToFloat b)
+        |> floatToAsset
 
 
 unitConverterRound4 : Int -> Int -> String

--- a/test/frontend/elm/Test/Component/Main/Page/Resource/Stake.elm
+++ b/test/frontend/elm/Test/Component/Main/Page/Resource/Stake.elm
@@ -1,0 +1,295 @@
+module Test.Component.Main.Page.Resource.Stake exposing (tests)
+
+import Component.Main.Page.Resource.Stake exposing (..)
+import Expect
+import Test exposing (..)
+import Util.Validation as Validation
+    exposing
+        ( AccountStatus(..)
+        , MemoStatus(..)
+        , QuantityStatus(..)
+        , validateAccount
+        , validateMemo
+        , validateQuantity
+        )
+
+
+
+-- TODO(boseok): tests for Stake.update
+
+
+tests : Test
+tests =
+    describe "Page.SearchKey module"
+        [ describe "getPercentageOfLiquid"
+            [ test "Percentage10" <|
+                \() ->
+                    Expect.equal 0.1 (getPercentageOfLiquid Percentage10)
+            , test "Percentage50" <|
+                \() ->
+                    Expect.equal 0.5 (getPercentageOfLiquid Percentage50)
+            , test "Percentage70" <|
+                \() ->
+                    Expect.equal 0.7 (getPercentageOfLiquid Percentage70)
+            , test "Percentage100" <|
+                \() ->
+                    Expect.equal 1 (getPercentageOfLiquid Percentage100)
+            , test "NoOp" <|
+                \() ->
+                    Expect.equal 0 (getPercentageOfLiquid NoOp)
+            ]
+        , describe "validate"
+            [ test "validate test1. modal closed, total = ValidQuantity" <|
+                \() ->
+                    let
+                        newModel =
+                            { delegatebw =
+                                { from = "", receiver = "", stakeNetQuantity = "0.0600 EOS", stakeCpuQuantity = "0.2400 EOS", transfer = 1 }
+                            , totalQuantity = "0.3"
+                            , percentageOfLiquid = NoOp
+                            , distributionRatio =
+                                { cpu = 4, net = 1 }
+                            , totalQuantityValidation = InvalidQuantity
+                            , cpuQuantityValidation = InvalidQuantity
+                            , netQuantityValidation = InvalidQuantity
+                            , manuallySet = False
+                            , isFormValid = False
+                            , isStakeAmountModalOpened = False
+                            , stakeAmountModal =
+                                { totalQuantity = "0"
+                                , cpuQuantity = ""
+                                , netQuantity = ""
+                                , totalQuantityValidation = EmptyQuantity
+                                , cpuQuantityValidation = EmptyQuantity
+                                , netQuantityValidation = EmptyQuantity
+                                , isFormValid = False
+                                }
+                            }
+
+                        liquidAmount =
+                            0.3532
+
+                        modalOpened =
+                            False
+
+                        expectedModel =
+                            { delegatebw =
+                                { from = ""
+                                , receiver = ""
+                                , stakeNetQuantity = "0.0600 EOS"
+                                , stakeCpuQuantity = "0.2400 EOS"
+                                , transfer = 1
+                                }
+                            , totalQuantity = "0.3"
+                            , percentageOfLiquid = NoOp
+                            , distributionRatio = { cpu = 4, net = 1 }
+                            , totalQuantityValidation = ValidQuantity
+                            , cpuQuantityValidation = ValidQuantity
+                            , netQuantityValidation = ValidQuantity
+                            , manuallySet = False
+                            , isFormValid = True
+                            , isStakeAmountModalOpened = False
+                            , stakeAmountModal = { totalQuantity = "0", cpuQuantity = "", netQuantity = "", totalQuantityValidation = EmptyQuantity, cpuQuantityValidation = EmptyQuantity, netQuantityValidation = EmptyQuantity, isFormValid = False }
+                            }
+                    in
+                    Expect.equal expectedModel (validate newModel liquidAmount modalOpened)
+            , test "validate test2. modal closed, total = OverValidQuantity" <|
+                \() ->
+                    let
+                        newModel =
+                            { delegatebw = { from = "", receiver = "", stakeNetQuantity = "0.0800 EOS", stakeCpuQuantity = "0.3200 EOS", transfer = 1 }
+                            , totalQuantity = "0.4"
+                            , percentageOfLiquid = NoOp
+                            , distributionRatio = { cpu = 4, net = 1 }
+                            , totalQuantityValidation = InvalidQuantity
+                            , cpuQuantityValidation = InvalidQuantity
+                            , netQuantityValidation = InvalidQuantity
+                            , manuallySet = False
+                            , isFormValid = False
+                            , isStakeAmountModalOpened = False
+                            , stakeAmountModal =
+                                { totalQuantity = "0"
+                                , cpuQuantity = ""
+                                , netQuantity = ""
+                                , totalQuantityValidation = EmptyQuantity
+                                , cpuQuantityValidation = EmptyQuantity
+                                , netQuantityValidation = EmptyQuantity
+                                , isFormValid =
+                                    False
+                                }
+                            }
+
+                        liquidAmount =
+                            0.3532
+
+                        modalOpened =
+                            False
+
+                        expectedModel =
+                            { delegatebw = { from = "", receiver = "", stakeNetQuantity = "0.0800 EOS", stakeCpuQuantity = "0.3200 EOS", transfer = 1 }
+                            , totalQuantity = "0.4"
+                            , percentageOfLiquid = NoOp
+                            , distributionRatio = { cpu = 4, net = 1 }
+                            , totalQuantityValidation = OverValidQuantity
+                            , cpuQuantityValidation = ValidQuantity
+                            , netQuantityValidation = ValidQuantity
+                            , manuallySet = False
+                            , isFormValid = False
+                            , isStakeAmountModalOpened = False
+                            , stakeAmountModal =
+                                { totalQuantity = "0"
+                                , cpuQuantity = ""
+                                , netQuantity = ""
+                                , totalQuantityValidation = EmptyQuantity
+                                , cpuQuantityValidation = EmptyQuantity
+                                , netQuantityValidation = EmptyQuantity
+                                , isFormValid = False
+                                }
+                            }
+                    in
+                    Expect.equal expectedModel (validate newModel liquidAmount modalOpened)
+            , test "validate test3. modal opened, cpu + net -> OverValidQuantity" <|
+                \() ->
+                    let
+                        newModel =
+                            { delegatebw = { from = "", receiver = "", stakeNetQuantity = "", stakeCpuQuantity = "", transfer = 1 }
+                            , totalQuantity = ""
+                            , percentageOfLiquid = NoOp
+                            , distributionRatio = { cpu = 4, net = 1 }
+                            , totalQuantityValidation = EmptyQuantity
+                            , cpuQuantityValidation = EmptyQuantity
+                            , netQuantityValidation = EmptyQuantity
+                            , manuallySet = False
+                            , isFormValid = False
+                            , isStakeAmountModalOpened = True
+                            , stakeAmountModal =
+                                { totalQuantity = "0.4"
+                                , cpuQuantity = "0.2"
+                                , netQuantity = "0.2"
+                                , totalQuantityValidation = ValidQuantity
+                                , cpuQuantityValidation = ValidQuantity
+                                , netQuantityValidation = InvalidQuantity
+                                , isFormValid = False
+                                }
+                            }
+
+                        liquidAmount =
+                            0.3532
+
+                        modalOpened =
+                            True
+
+                        expectedModel =
+                            { delegatebw = { from = "", receiver = "", stakeNetQuantity = "", stakeCpuQuantity = "", transfer = 1 }
+                            , totalQuantity = ""
+                            , percentageOfLiquid = NoOp
+                            , distributionRatio = { cpu = 4, net = 1 }
+                            , totalQuantityValidation = EmptyQuantity
+                            , cpuQuantityValidation = EmptyQuantity
+                            , netQuantityValidation = EmptyQuantity
+                            , manuallySet = False
+                            , isFormValid = False
+                            , isStakeAmountModalOpened = True
+                            , stakeAmountModal =
+                                { totalQuantity = "0.4"
+                                , cpuQuantity = "0.2"
+                                , netQuantity = "0.2"
+                                , totalQuantityValidation = OverValidQuantity
+                                , cpuQuantityValidation = ValidQuantity
+                                , netQuantityValidation = ValidQuantity
+                                , isFormValid = False
+                                }
+                            }
+                    in
+                    Expect.equal expectedModel (validate newModel liquidAmount modalOpened)
+            , test "validate test4. modal opened, cpu + net -> ValidQuantity" <|
+                \() ->
+                    let
+                        newModel =
+                            { delegatebw =
+                                { from = ""
+                                , receiver = ""
+                                , stakeNetQuantity = ""
+                                , stakeCpuQuantity = ""
+                                , transfer = 1
+                                }
+                            , totalQuantity = ""
+                            , percentageOfLiquid = NoOp
+                            , distributionRatio = { cpu = 4, net = 1 }
+                            , totalQuantityValidation = EmptyQuantity
+                            , cpuQuantityValidation = EmptyQuantity
+                            , netQuantityValidation = EmptyQuantity
+                            , manuallySet = False
+                            , isFormValid = False
+                            , isStakeAmountModalOpened = True
+                            , stakeAmountModal =
+                                { totalQuantity = "0.3"
+                                , cpuQuantity = "0.2"
+                                , netQuantity = "0.1"
+                                , totalQuantityValidation = ValidQuantity
+                                , cpuQuantityValidation = ValidQuantity
+                                , netQuantityValidation = InvalidQuantity
+                                , isFormValid = False
+                                }
+                            }
+
+                        liquidAmount =
+                            0.3532
+
+                        modalOpened =
+                            True
+
+                        expectedModel =
+                            { delegatebw =
+                                { from = ""
+                                , receiver = ""
+                                , stakeNetQuantity = ""
+                                , stakeCpuQuantity = ""
+                                , transfer = 1
+                                }
+                            , totalQuantity = ""
+                            , percentageOfLiquid = NoOp
+                            , distributionRatio = { cpu = 4, net = 1 }
+                            , totalQuantityValidation = EmptyQuantity
+                            , cpuQuantityValidation = EmptyQuantity
+                            , netQuantityValidation = EmptyQuantity
+                            , manuallySet = False
+                            , isFormValid = False
+                            , isStakeAmountModalOpened = True
+                            , stakeAmountModal =
+                                { totalQuantity = "0.3"
+                                , cpuQuantity = "0.2"
+                                , netQuantity = "0.1"
+                                , totalQuantityValidation = ValidQuantity
+                                , cpuQuantityValidation = ValidQuantity
+                                , netQuantityValidation = ValidQuantity
+                                , isFormValid = True
+                                }
+                            }
+                    in
+                    Expect.equal expectedModel (validate newModel liquidAmount modalOpened)
+            ]
+        , describe "distributeCpuNet"
+            [ test "distributeCpuNet \"1.0000 EOS\" 1 2 " <|
+                \() ->
+                    let
+                        expected =
+                            ( "0.3333 EOS", "0.6667 EOS" )
+                    in
+                    Expect.equal expected (distributeCpuNet "1.0000 EOS" 1 2)
+            ]
+        , describe "modalValidateAttr"
+            [ test "resourceQuantityStatus -> EmptyQuantity" <|
+                \() ->
+                    Expect.equal "" (modalValidateAttr InvalidQuantity EmptyQuantity)
+            , test "resourceQuantityStatus -> ValidQuantity, but totalQuantityStatus -> not ValidQuantity" <|
+                \() ->
+                    Expect.equal "false" (modalValidateAttr InvalidQuantity ValidQuantity)
+            , test "resourceQuantityStatus -> ValidQuantity && totalQuantityStatus -> ValidQuantity" <|
+                \() ->
+                    Expect.equal "true" (modalValidateAttr ValidQuantity ValidQuantity)
+            , test "resourceQuantityStatus -> else cases " <|
+                \() ->
+                    Expect.equal "false" (modalValidateAttr InvalidQuantity InvalidQuantity)
+            ]
+        ]

--- a/test/frontend/elm/Test/Component/Main/Page/Resource/Stake.elm
+++ b/test/frontend/elm/Test/Component/Main/Page/Resource/Stake.elm
@@ -39,31 +39,26 @@ tests =
                     Expect.equal 0 (getPercentageOfLiquid NoOp)
             ]
         , describe "validate"
+            -- TODO(boseok): these tests only cover totalQuantity validation and modal open/close validation cases
+            -- rest cases are TODO
             [ test "validate test1. modal closed, total = ValidQuantity" <|
                 \() ->
                     let
+                        defaultModel =
+                            initModel
+
+                        { delegatebw } =
+                            defaultModel
+
                         newModel =
-                            { delegatebw =
-                                { from = "", receiver = "", stakeNetQuantity = "0.0600 EOS", stakeCpuQuantity = "0.2400 EOS", transfer = 1 }
-                            , totalQuantity = "0.3"
-                            , percentageOfLiquid = NoOp
-                            , distributionRatio =
-                                { cpu = 4, net = 1 }
-                            , totalQuantityValidation = InvalidQuantity
-                            , cpuQuantityValidation = InvalidQuantity
-                            , netQuantityValidation = InvalidQuantity
-                            , manuallySet = False
-                            , isFormValid = False
-                            , isStakeAmountModalOpened = False
-                            , stakeAmountModal =
-                                { totalQuantity = "0"
-                                , cpuQuantity = ""
-                                , netQuantity = ""
-                                , totalQuantityValidation = EmptyQuantity
-                                , cpuQuantityValidation = EmptyQuantity
-                                , netQuantityValidation = EmptyQuantity
-                                , isFormValid = False
-                                }
+                            { defaultModel
+                                | delegatebw =
+                                    { delegatebw
+                                        | stakeNetQuantity = "0.0600 EOS"
+                                        , stakeCpuQuantity = "0.2400 EOS"
+                                        , transfer = 1
+                                    }
+                                , totalQuantity = "0.3"
                             }
 
                         liquidAmount =
@@ -73,50 +68,32 @@ tests =
                             False
 
                         expectedModel =
-                            { delegatebw =
-                                { from = ""
-                                , receiver = ""
-                                , stakeNetQuantity = "0.0600 EOS"
-                                , stakeCpuQuantity = "0.2400 EOS"
-                                , transfer = 1
-                                }
-                            , totalQuantity = "0.3"
-                            , percentageOfLiquid = NoOp
-                            , distributionRatio = { cpu = 4, net = 1 }
-                            , totalQuantityValidation = ValidQuantity
-                            , cpuQuantityValidation = ValidQuantity
-                            , netQuantityValidation = ValidQuantity
-                            , manuallySet = False
-                            , isFormValid = True
-                            , isStakeAmountModalOpened = False
-                            , stakeAmountModal = { totalQuantity = "0", cpuQuantity = "", netQuantity = "", totalQuantityValidation = EmptyQuantity, cpuQuantityValidation = EmptyQuantity, netQuantityValidation = EmptyQuantity, isFormValid = False }
+                            { newModel
+                                | totalQuantityValidation = ValidQuantity
+                                , cpuQuantityValidation = ValidQuantity
+                                , netQuantityValidation = ValidQuantity
+                                , isFormValid = True
                             }
                     in
                     Expect.equal expectedModel (validate newModel liquidAmount modalOpened)
             , test "validate test2. modal closed, total = OverValidQuantity" <|
                 \() ->
                     let
+                        defaultModel =
+                            initModel
+
+                        { delegatebw } =
+                            defaultModel
+
                         newModel =
-                            { delegatebw = { from = "", receiver = "", stakeNetQuantity = "0.0800 EOS", stakeCpuQuantity = "0.3200 EOS", transfer = 1 }
-                            , totalQuantity = "0.4"
-                            , percentageOfLiquid = NoOp
-                            , distributionRatio = { cpu = 4, net = 1 }
-                            , totalQuantityValidation = InvalidQuantity
-                            , cpuQuantityValidation = InvalidQuantity
-                            , netQuantityValidation = InvalidQuantity
-                            , manuallySet = False
-                            , isFormValid = False
-                            , isStakeAmountModalOpened = False
-                            , stakeAmountModal =
-                                { totalQuantity = "0"
-                                , cpuQuantity = ""
-                                , netQuantity = ""
-                                , totalQuantityValidation = EmptyQuantity
-                                , cpuQuantityValidation = EmptyQuantity
-                                , netQuantityValidation = EmptyQuantity
-                                , isFormValid =
-                                    False
-                                }
+                            { defaultModel
+                                | delegatebw =
+                                    { delegatebw
+                                        | stakeNetQuantity = "0.0800 EOS"
+                                        , stakeCpuQuantity = "0.3200 EOS"
+                                        , transfer = 1
+                                    }
+                                , totalQuantity = "0.4"
                             }
 
                         liquidAmount =
@@ -126,51 +103,31 @@ tests =
                             False
 
                         expectedModel =
-                            { delegatebw = { from = "", receiver = "", stakeNetQuantity = "0.0800 EOS", stakeCpuQuantity = "0.3200 EOS", transfer = 1 }
-                            , totalQuantity = "0.4"
-                            , percentageOfLiquid = NoOp
-                            , distributionRatio = { cpu = 4, net = 1 }
-                            , totalQuantityValidation = OverValidQuantity
-                            , cpuQuantityValidation = ValidQuantity
-                            , netQuantityValidation = ValidQuantity
-                            , manuallySet = False
-                            , isFormValid = False
-                            , isStakeAmountModalOpened = False
-                            , stakeAmountModal =
-                                { totalQuantity = "0"
-                                , cpuQuantity = ""
-                                , netQuantity = ""
-                                , totalQuantityValidation = EmptyQuantity
-                                , cpuQuantityValidation = EmptyQuantity
-                                , netQuantityValidation = EmptyQuantity
+                            { newModel
+                                | totalQuantityValidation = OverValidQuantity
+                                , cpuQuantityValidation = ValidQuantity
+                                , netQuantityValidation = ValidQuantity
                                 , isFormValid = False
-                                }
                             }
                     in
                     Expect.equal expectedModel (validate newModel liquidAmount modalOpened)
             , test "validate test3. modal opened, cpu + net -> OverValidQuantity" <|
                 \() ->
                     let
+                        defaultModel =
+                            initModel
+
+                        { stakeAmountModal } =
+                            defaultModel
+
                         newModel =
-                            { delegatebw = { from = "", receiver = "", stakeNetQuantity = "", stakeCpuQuantity = "", transfer = 1 }
-                            , totalQuantity = ""
-                            , percentageOfLiquid = NoOp
-                            , distributionRatio = { cpu = 4, net = 1 }
-                            , totalQuantityValidation = EmptyQuantity
-                            , cpuQuantityValidation = EmptyQuantity
-                            , netQuantityValidation = EmptyQuantity
-                            , manuallySet = False
-                            , isFormValid = False
-                            , isStakeAmountModalOpened = True
-                            , stakeAmountModal =
-                                { totalQuantity = "0.4"
-                                , cpuQuantity = "0.2"
-                                , netQuantity = "0.2"
-                                , totalQuantityValidation = ValidQuantity
-                                , cpuQuantityValidation = ValidQuantity
-                                , netQuantityValidation = InvalidQuantity
-                                , isFormValid = False
-                                }
+                            { defaultModel
+                                | stakeAmountModal =
+                                    { stakeAmountModal
+                                        | totalQuantity = "0.4"
+                                        , cpuQuantity = "0.2"
+                                        , netQuantity = "0.2"
+                                    }
                             }
 
                         liquidAmount =
@@ -179,92 +136,59 @@ tests =
                         modalOpened =
                             True
 
+                        newStakeAmountModal =
+                            newModel.stakeAmountModal
+
                         expectedModel =
-                            { delegatebw = { from = "", receiver = "", stakeNetQuantity = "", stakeCpuQuantity = "", transfer = 1 }
-                            , totalQuantity = ""
-                            , percentageOfLiquid = NoOp
-                            , distributionRatio = { cpu = 4, net = 1 }
-                            , totalQuantityValidation = EmptyQuantity
-                            , cpuQuantityValidation = EmptyQuantity
-                            , netQuantityValidation = EmptyQuantity
-                            , manuallySet = False
-                            , isFormValid = False
-                            , isStakeAmountModalOpened = True
-                            , stakeAmountModal =
-                                { totalQuantity = "0.4"
-                                , cpuQuantity = "0.2"
-                                , netQuantity = "0.2"
-                                , totalQuantityValidation = OverValidQuantity
-                                , cpuQuantityValidation = ValidQuantity
-                                , netQuantityValidation = ValidQuantity
-                                , isFormValid = False
-                                }
+                            { newModel
+                                | stakeAmountModal =
+                                    { newStakeAmountModal
+                                        | totalQuantityValidation = OverValidQuantity
+                                        , cpuQuantityValidation = ValidQuantity
+                                        , netQuantityValidation = ValidQuantity
+                                        , isFormValid = False
+                                    }
                             }
                     in
                     Expect.equal expectedModel (validate newModel liquidAmount modalOpened)
             , test "validate test4. modal opened, cpu + net -> ValidQuantity" <|
                 \() ->
                     let
+                        defaultModel =
+                            initModel
+
+                        { stakeAmountModal } =
+                            defaultModel
+
                         newModel =
-                            { delegatebw =
-                                { from = ""
-                                , receiver = ""
-                                , stakeNetQuantity = ""
-                                , stakeCpuQuantity = ""
-                                , transfer = 1
-                                }
-                            , totalQuantity = ""
-                            , percentageOfLiquid = NoOp
-                            , distributionRatio = { cpu = 4, net = 1 }
-                            , totalQuantityValidation = EmptyQuantity
-                            , cpuQuantityValidation = EmptyQuantity
-                            , netQuantityValidation = EmptyQuantity
-                            , manuallySet = False
-                            , isFormValid = False
-                            , isStakeAmountModalOpened = True
-                            , stakeAmountModal =
-                                { totalQuantity = "0.3"
-                                , cpuQuantity = "0.2"
-                                , netQuantity = "0.1"
-                                , totalQuantityValidation = ValidQuantity
-                                , cpuQuantityValidation = ValidQuantity
-                                , netQuantityValidation = InvalidQuantity
-                                , isFormValid = False
-                                }
+                            { defaultModel
+                                | stakeAmountModal =
+                                    { stakeAmountModal
+                                        | totalQuantity = "0.3"
+                                        , cpuQuantity = "0.2"
+                                        , netQuantity = "0.1"
+                                    }
+                                , isStakeAmountModalOpened = True
                             }
 
                         liquidAmount =
                             0.3532
 
                         modalOpened =
-                            True
+                            newModel.isStakeAmountModalOpened
+
+                        newStakeAmountModal =
+                            newModel.stakeAmountModal
 
                         expectedModel =
-                            { delegatebw =
-                                { from = ""
-                                , receiver = ""
-                                , stakeNetQuantity = ""
-                                , stakeCpuQuantity = ""
-                                , transfer = 1
-                                }
-                            , totalQuantity = ""
-                            , percentageOfLiquid = NoOp
-                            , distributionRatio = { cpu = 4, net = 1 }
-                            , totalQuantityValidation = EmptyQuantity
-                            , cpuQuantityValidation = EmptyQuantity
-                            , netQuantityValidation = EmptyQuantity
-                            , manuallySet = False
-                            , isFormValid = False
-                            , isStakeAmountModalOpened = True
-                            , stakeAmountModal =
-                                { totalQuantity = "0.3"
-                                , cpuQuantity = "0.2"
-                                , netQuantity = "0.1"
-                                , totalQuantityValidation = ValidQuantity
-                                , cpuQuantityValidation = ValidQuantity
-                                , netQuantityValidation = ValidQuantity
-                                , isFormValid = True
-                                }
+                            { newModel
+                                | stakeAmountModal =
+                                    { newStakeAmountModal
+                                        | totalQuantityValidation = ValidQuantity
+                                        , cpuQuantityValidation = ValidQuantity
+                                        , netQuantityValidation = ValidQuantity
+                                        , isFormValid = True
+                                    }
                             }
                     in
                     Expect.equal expectedModel (validate newModel liquidAmount modalOpened)

--- a/test/frontend/elm/Test/Util/Formatter.elm
+++ b/test/frontend/elm/Test/Util/Formatter.elm
@@ -15,15 +15,25 @@ tests =
                 \() ->
                     Expect.equal 1.0 (larimerToEos 10000)
             ]
-        , describe "eosFloatToString"
+        , describe "floatToAsset"
             [ test "0.1 -> \"0.1000 EOS\"" <|
                 \() ->
-                    Expect.equal "0.1000 EOS" (eosFloatToString 0.1)
+                    Expect.equal "0.1000 EOS" (floatToAsset 0.1)
             ]
-        , describe "eosStringToFloat"
+        , describe "assetToFloat"
             [ test "\"0.1 EOS\" -> 0.1" <|
                 \() ->
-                    Expect.equal 0.1 (eosStringToFloat "0.1 EOS")
+                    Expect.equal 0.1 (assetToFloat "0.1 EOS")
+            ]
+        , describe "assetAdd"
+            [ test "\"0.5000 EOS\" + \"0.5000 EOS\"" <|
+                \() ->
+                    Expect.equal "1.0000 EOS" (assetAdd "0.5000 EOS" "0.5000 EOS")
+            ]
+        , describe "assetSubtract"
+            [ test "\"1.0000 EOS\" - \"0.5000 EOS\"" <|
+                \() ->
+                    Expect.equal "0.5000 EOS" (assetSubtract "1.0000 EOS" "0.5000 EOS")
             ]
         , describe "unitConverterRound4"
             [ test "1024 -> 1k" <|
@@ -34,25 +44,25 @@ tests =
             [ test "1/100 * 100 = 1%" <|
                 \() ->
                     Expect.equal 1.0 (percentageConverter 1 100)
-            , describe "timeFormatter"
-                [ test "English, AM, Ok" <|
-                    \() ->
-                        Expect.equal "2:16:21 AM, August 17, 2018" (timeFormatter English "2018-08-17T02:16:21.500")
-                , test "English, PM, Ok" <|
-                    \() ->
-                        Expect.equal "5:16:21 PM, August 17, 2018" (timeFormatter English "2018-08-17T17:16:21.500")
-                , test "Korean, AM, Ok" <|
-                    \() ->
-                        Expect.equal "2018년, 8월 17일, 2:16:21 AM" (timeFormatter Korean "2018-08-17T02:16:21.500")
-                , test "Korean, PM, Ok" <|
-                    \() ->
-                        Expect.equal "2018년, 8월 17일, 5:16:21 PM" (timeFormatter Korean "2018-08-17T17:16:21.500")
-                , test "invalid time, Err" <|
-                    \() ->
-                        Expect.equal "Failed to create a Date from string '2018-108-17T17:16:21.500': Invalid ISO 8601 format" (timeFormatter English "2018-108-17T17:16:21.500")
-                , test "no time, Err" <|
-                    \() ->
-                        Expect.equal "Failed to create a Date from string '': Invalid ISO 8601 format" (timeFormatter English "")
-                ]
+            ]
+        , describe "timeFormatter"
+            [ test "English, AM, Ok" <|
+                \() ->
+                    Expect.equal "2:16:21 AM, August 17, 2018" (timeFormatter English "2018-08-17T02:16:21.500")
+            , test "English, PM, Ok" <|
+                \() ->
+                    Expect.equal "5:16:21 PM, August 17, 2018" (timeFormatter English "2018-08-17T17:16:21.500")
+            , test "Korean, AM, Ok" <|
+                \() ->
+                    Expect.equal "2018년, 8월 17일, 2:16:21 AM" (timeFormatter Korean "2018-08-17T02:16:21.500")
+            , test "Korean, PM, Ok" <|
+                \() ->
+                    Expect.equal "2018년, 8월 17일, 5:16:21 PM" (timeFormatter Korean "2018-08-17T17:16:21.500")
+            , test "invalid time, Err" <|
+                \() ->
+                    Expect.equal "Failed to create a Date from string '2018-108-17T17:16:21.500': Invalid ISO 8601 format" (timeFormatter English "2018-108-17T17:16:21.500")
+            , test "no time, Err" <|
+                \() ->
+                    Expect.equal "Failed to create a Date from string '': Invalid ISO 8601 format" (timeFormatter English "")
             ]
         ]


### PR DESCRIPTION
1. Modal이 각 Tab안으로 들어갔습니다.
2. cpu, net 계산 로직과 validation이 추가 되었습니다.

NOTE
번역 부분은 TODO로 남겨 놓습니다.
viewStakeAmountModal을 module로 떼어내려고 하였으나, Stake 모듈의 Model들을 공유하여 Stake 모듈에 남겨 두었습니다.