### PR TITLE
Change time format 2018/08/17 YYYY/MM/dd HH:mm:ss

### DIFF
--- a/app/frontend/src/elm/Component/Main/Page/Rammarket.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Rammarket.elm
@@ -750,7 +750,7 @@ actionToTableRow language { blockTime, data, trxId } =
                         ( "log buy", "구매", from )
 
                 formattedDateTime =
-                    blockTime |> timeFormatter language
+                    blockTime |> timeFormatter
             in
             tr [ class actionClass ]
                 [ td [] [ text actionType ]

--- a/app/frontend/src/elm/Component/Main/Page/Search.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Search.elm
@@ -404,7 +404,7 @@ viewAction language selectedActionCategory accountName openedActionSeq ({ accoun
         , td []
             [ text actionTag ]
         , td []
-            [ text (timeFormatter language blockTime) ]
+            [ text (timeFormatter blockTime) ]
         , Html.map ActionMessage (viewActionInfo accountName action openedActionSeq)
         ]
 

--- a/app/frontend/src/elm/Util/Formatter.elm
+++ b/app/frontend/src/elm/Util/Formatter.elm
@@ -165,14 +165,13 @@ timeFormatter language time =
         Ok date ->
             case language of
                 Korean ->
-                    Date.toFormattedString "YYYY년, M월 d일, h:mm:ss a" date
+                    Date.toFormattedString "YYYY/MM/dd HH:mm:ss" date
 
                 English ->
-                    Date.toFormattedString "h:mm:ss a, MMMM d, YYYY" date
+                    Date.toFormattedString "YYYY/MM/dd HH:mm:ss" date
 
                 Chinese ->
-                    -- TODO(boseok): Add chinese
-                    Date.toFormattedString "h:mm:ss a, MMMM d, YYYY" date
+                    Date.toFormattedString "YYYY/MM/dd HH:mm:ss" date
 
         Err str ->
             str

--- a/app/frontend/src/elm/Util/Formatter.elm
+++ b/app/frontend/src/elm/Util/Formatter.elm
@@ -159,19 +159,11 @@ formatAsset value =
 -- Time
 
 
-timeFormatter : Language -> String -> String
-timeFormatter language time =
+timeFormatter : String -> String
+timeFormatter time =
     case Date.fromIsoString time of
         Ok date ->
-            case language of
-                Korean ->
-                    Date.toFormattedString "YYYY/MM/dd HH:mm:ss" date
-
-                English ->
-                    Date.toFormattedString "YYYY/MM/dd HH:mm:ss" date
-
-                Chinese ->
-                    Date.toFormattedString "YYYY/MM/dd HH:mm:ss" date
+            Date.toFormattedString "YYYY/MM/dd HH:mm:ss" date
 
         Err str ->
             str

--- a/test/frontend/elm/Test/Util/Formatter.elm
+++ b/test/frontend/elm/Test/Util/Formatter.elm
@@ -51,18 +51,19 @@ tests =
                     Expect.equal 1.0 (percentageConverter 1 100)
             ]
         , describe "timeFormatter"
+            -- TODO(boseok): distinction by language is useless if the format type is fixed list this
             [ test "English, AM, Ok" <|
                 \() ->
-                    Expect.equal "2:16:21 AM, August 17, 2018" (timeFormatter English "2018-08-17T02:16:21.500")
+                    Expect.equal "2018/08/17 02:16:21" (timeFormatter English "2018-08-17T02:16:21.500")
             , test "English, PM, Ok" <|
                 \() ->
-                    Expect.equal "5:16:21 PM, August 17, 2018" (timeFormatter English "2018-08-17T17:16:21.500")
+                    Expect.equal "2018/08/17 17:16:21" (timeFormatter English "2018-08-17T17:16:21.500")
             , test "Korean, AM, Ok" <|
                 \() ->
-                    Expect.equal "2018년, 8월 17일, 2:16:21 AM" (timeFormatter Korean "2018-08-17T02:16:21.500")
+                    Expect.equal "2018/08/17 02:16:21" (timeFormatter Korean "2018-08-17T02:16:21.500")
             , test "Korean, PM, Ok" <|
                 \() ->
-                    Expect.equal "2018년, 8월 17일, 5:16:21 PM" (timeFormatter Korean "2018-08-17T17:16:21.500")
+                    Expect.equal "2018/08/17 17:16:21" (timeFormatter Korean "2018-08-17T17:16:21.500")
             , test "invalid time, Err" <|
                 \() ->
                     Expect.equal "Failed to create a Date from string '2018-108-17T17:16:21.500': Invalid ISO 8601 format" (timeFormatter English "2018-108-17T17:16:21.500")

--- a/test/frontend/elm/Test/Util/Formatter.elm
+++ b/test/frontend/elm/Test/Util/Formatter.elm
@@ -51,25 +51,18 @@ tests =
                     Expect.equal 1.0 (percentageConverter 1 100)
             ]
         , describe "timeFormatter"
-            -- TODO(boseok): distinction by language is useless if the format type is fixed list this
-            [ test "English, AM, Ok" <|
+            [ test "AM, Ok" <|
                 \() ->
-                    Expect.equal "2018/08/17 02:16:21" (timeFormatter English "2018-08-17T02:16:21.500")
-            , test "English, PM, Ok" <|
+                    Expect.equal "2018/08/17 02:16:21" (timeFormatter "2018-08-17T02:16:21.500")
+            , test "PM, Ok" <|
                 \() ->
-                    Expect.equal "2018/08/17 17:16:21" (timeFormatter English "2018-08-17T17:16:21.500")
-            , test "Korean, AM, Ok" <|
-                \() ->
-                    Expect.equal "2018/08/17 02:16:21" (timeFormatter Korean "2018-08-17T02:16:21.500")
-            , test "Korean, PM, Ok" <|
-                \() ->
-                    Expect.equal "2018/08/17 17:16:21" (timeFormatter Korean "2018-08-17T17:16:21.500")
+                    Expect.equal "2018/08/17 17:16:21" (timeFormatter "2018-08-17T17:16:21.500")
             , test "invalid time, Err" <|
                 \() ->
-                    Expect.equal "Failed to create a Date from string '2018-108-17T17:16:21.500': Invalid ISO 8601 format" (timeFormatter English "2018-108-17T17:16:21.500")
+                    Expect.equal "Failed to create a Date from string '2018-108-17T17:16:21.500': Invalid ISO 8601 format" (timeFormatter "2018-108-17T17:16:21.500")
             , test "no time, Err" <|
                 \() ->
-                    Expect.equal "Failed to create a Date from string '': Invalid ISO 8601 format" (timeFormatter English "")
+                    Expect.equal "Failed to create a Date from string '': Invalid ISO 8601 format" (timeFormatter  "")
             ]
         , describe "deleteFromBack"
             [ test "remove 4 characters." <|


### PR DESCRIPTION
```
검색 페이지 검색결과 테이블 내의 datetime format을 yyyy/mm/dd HH:mm:ss 로 변경해주세요. @진훈
```
반영했습니다. timeFormatter를 사용하는 모든 time format에 적용됩니다. 