### PR TITLE
adjust popup position

### DIFF
--- a/app/frontend/src/stylesheets/layout.scss
+++ b/app/frontend/src/stylesheets/layout.scss
@@ -352,7 +352,8 @@ aside.shrink {
 		background-color:$x-dark-gray;
 
 		position:absolute;
-		top:calc(#{$header_height} + 61px + 100px);		// 대충 중간...
+		top:calc(50% + 61px/2);
+		// top:calc(#{$header_height} + 61px + 100px);		// 대충 중간...
 		left:50%;
 		min-width:386px;
 		width:30.15625%;
@@ -361,6 +362,7 @@ aside.shrink {
 
 		padding:32px 0;
 		box-sizing:border-box;
+		z-index:100;
 	}
 
 	//layout for scroll area
@@ -524,7 +526,7 @@ aside.shrink {
 
 	.wrapper {
 		transition:transform 0.4s;
-		transform:translate(-50%, -10%);
+		transform:translate(-50%, -60%);
 	}
 
 	&.viewing {
@@ -532,7 +534,7 @@ aside.shrink {
 		visibility:visible;
 
 		.wrapper {
-			transform:translate(-50%, 0);
+			transform:translate(-50%, -50%);
 		}
 	}
 


### PR DESCRIPTION
[QA 대응]
스테이크 -> ‘직접설정’ 누르면 뜨는 레이어 맥북 크롬에서 X버튼이 보이지 않아 끌 수가 없음. 모든 레이어는 바깥 영역 클릭시 사라지도록 개선.

화면 크기가 작을때의 1차 개선안으로  팝업의 위치를 gnb를 제외한 화면 세로 크기의 중간에 열어주도록 했습니다.