### PR TITLE
Fix timezone error of payment api response

### DIFF
--- a/app/controllers/payment_results_controller.rb
+++ b/app/controllers/payment_results_controller.rb
@@ -11,7 +11,7 @@ class PaymentResultsController < ApiController
         cid: @payment_result_params[:cid],
         tid: @payment_result_params[:tid],
         pay_info: @payment_result_params[:pay_info],
-        transaction_date: DateTime.parse(@payment_result_params[:transaction_date]),
+        transaction_date: DateTime.parse(@payment_result_params[:transaction_date]) - 9.hours,
         code: @payment_result_params[:code],
         message: @payment_result_params[:message],
       )


### PR DESCRIPTION
Payment api response time representation has no timezone info and is local time(+9:00)