### PR TITLE
Controlling event

### DIFF
--- a/app/admin/products.rb
+++ b/app/admin/products.rb
@@ -1,11 +1,12 @@
 ActiveAdmin.register Product do
   menu priority: 3
-  permit_params :active, :name, :price
+  permit_params :active, :name, :price, :event_activation
 
   index do
     selectable_column
     id_column
     toggle_bool_column :active
+    toggle_bool_column :event_activation
     column :name
     number_column :price, as: :currency, unit: "원", separator: ","
     column :created_at
@@ -16,6 +17,7 @@ ActiveAdmin.register Product do
   show do
     attributes_table do
       bool_row :active
+      bool_row :event_activation
       row :name
       number_row :price, as: :currency, unit: "원", separator: ","
       row :created_at
@@ -27,6 +29,7 @@ ActiveAdmin.register Product do
   form do |f|
     f.inputs do
       f.input :active
+      f.input :event_activation
       f.input :name
       f.input :price
     end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,8 +1,8 @@
 class ProductsController < ApplicationController
   def eos_account
-    product = Product.where(name: 'EOS Account').where(active: true).take
-    raise Exceptions::DefaultError, Exceptions::DEACTIVATED_PRODUCT if product.blank?
+    eos_account_product = Product.eos_account
+    raise Exceptions::DefaultError, Exceptions::DEACTIVATED_PRODUCT if eos_account_product.blank?
 
-    render json: product, status: :ok
+    render json: eos_account_product, status: :ok
   end
 end

--- a/app/exceptions/exceptions.rb
+++ b/app/exceptions/exceptions.rb
@@ -10,6 +10,7 @@ module Exceptions
   ORDER_ALREADY_DELIVERED = { message: I18n.t('orders.order_already_delivered'), error_code: 6, status_code: :bad_request }.freeze
   PAYMENT_SERVER_NOT_RESPOND = { message: I18n.t('orders.payment_server_not_respond'), error_code: 7, status_code: :internal_server_error }.freeze
   INVALID_PAYMENT_RESULT_CALLBACK = { message: I18n.t('payment_results.invalid_payment_result_callback'), error_code: 8, status_code: :not_acceptable }.freeze
+  NOT_EVENT_PERIOD = { message: I18n.t('users.not_event_period'), error_code: 9, status_code: :not_acceptable }.freeze
 
   class DefaultError < RuntimeError
     attr_accessor :status_code, :error_code, :objects

--- a/app/frontend/src/elm/Component/Account/AccountComponent.elm
+++ b/app/frontend/src/elm/Component/Account/AccountComponent.elm
@@ -262,7 +262,7 @@ getPage route =
             CreatedPage (Created.initModel maybeEosAccount maybePublicKey)
 
         EventCreationRoute _ ->
-            NotFoundPage
+            EventCreationPage EventCreation.initModel
 
         _ ->
             NotFoundPage

--- a/app/frontend/src/elm/Component/Account/Page/Create.elm
+++ b/app/frontend/src/elm/Component/Account/Page/Create.elm
@@ -166,8 +166,16 @@ update msg ({ accountName, keys, notification } as model) flags language =
         GenerateKeys ->
             ( model, Port.generateKeys () )
 
-        ResultEosAccountProduct (Ok res) ->
-            ( { model | product = res }, Cmd.none )
+        ResultEosAccountProduct (Ok product) ->
+            let
+                cmd =
+                    if product.eventActivation then
+                        Navigation.newUrl ("/account/event_creation?locale=" ++ toLocale language)
+
+                    else
+                        Cmd.none
+            in
+            ( { model | product = product }, cmd )
 
         ResultEosAccountProduct (Err error) ->
             let

--- a/app/frontend/src/elm/Data/Json.elm
+++ b/app/frontend/src/elm/Data/Json.elm
@@ -20,7 +20,6 @@ module Data.Json exposing
     , voteStatDecoder
     )
 
-import Http
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline exposing (decode, required)
 
@@ -143,6 +142,7 @@ type alias Product =
     { id : Int
     , name : String
     , price : Int
+    , eventActivation : Bool
     }
 
 
@@ -151,6 +151,7 @@ initProduct =
     { id = 0
     , name = ""
     , price = 0
+    , eventActivation = False
     }
 
 
@@ -160,6 +161,7 @@ productDecoder =
         |> required "id" Decode.int
         |> required "name" Decode.string
         |> required "price" Decode.int
+        |> required "event_activation" Decode.bool
 
 
 type alias CreateEosAccountResponse =

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -21,6 +21,8 @@ class Product < ApplicationRecord
   validates :active, inclusion: { in: [true, false] }
   validates :event_activation, inclusion: { in: [true, false] }
 
+  scope :eos_account, -> { where(name: 'EOS Account').where(active: true).take }
+
   def as_json(*args)
     { id: id, name: name, price: price, event_activation: event_activation }
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -19,7 +19,6 @@ class Product < ApplicationRecord
   validates :name, presence: true
   validates :price, presence: true
   validates :active, inclusion: { in: [true, false] }
-  validates :event_activation, inclusion: { in: [true, false] }
 
   scope :eos_account, -> { where(name: 'EOS Account').where(active: true).take }
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,12 +2,13 @@
 #
 # Table name: products
 #
-#  id         :bigint(8)        not null, primary key
-#  active     :boolean          default(FALSE), not null
-#  name       :string           not null
-#  price      :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :bigint(8)        not null, primary key
+#  active           :boolean          default(FALSE), not null
+#  event_activation :boolean          default(FALSE), not null
+#  name             :string           not null
+#  price            :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #
@@ -18,8 +19,9 @@ class Product < ApplicationRecord
   validates :name, presence: true
   validates :price, presence: true
   validates :active, inclusion: { in: [true, false] }
+  validates :event_activation, inclusion: { in: [true, false] }
 
   def as_json(*args)
-    { id: id, name: name, price: price }
+    { id: id, name: name, price: price, event_activation: event_activation }
   end
 end

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -14,6 +14,7 @@ en:
     eos_account_creation_failure_already_created: 'EOS account already created with this email'
     eos_node_connection_failed: 'Failed to connect EOS node'
     eos_wallet_connection_failed: 'Failed to connect EOS wallet'
+    not_event_activated: 'Not event period'
   orders:
     deactivated_product: "You can't order this item for now"
     order_not_exist: "The order does not exist"

--- a/config/locales/controllers/ko.yml
+++ b/config/locales/controllers/ko.yml
@@ -14,6 +14,7 @@ ko:
     eos_account_creation_failure_already_created: '해당 이메일로 이미 EOS 계정을 생성하였습니다.'
     eos_node_connection_failed: 'EOS 노드 접속에 실패하였습니다.'
     eos_wallet_connection_failed: 'EOS 지갑 서버 접속에 실패하였습니다. 관리자에게 연락해주세요.'
+    not_event_activated: '이벤트 기간이 아닙니다.'
   orders:
     deactivated_product: '해당 상품은 현재 주문하실 수 없습니다.'
     order_not_exist: "해당 주문이 존재하지 않습니다."

--- a/db/migrate/20181019013513_add_event_activation_to_product.rb
+++ b/db/migrate/20181019013513_add_event_activation_to_product.rb
@@ -1,0 +1,5 @@
+class AddEventActivationToProduct < ActiveRecord::Migration[5.2]
+  def change
+    add_column :products, :event_activation, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_18_030038) do
+ActiveRecord::Schema.define(version: 2018_10_19_013513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,6 +129,7 @@ ActiveRecord::Schema.define(version: 2018_10_18_030038) do
     t.boolean "active", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "event_activation", default: false, null: false
     t.index ["name"], name: "index_products_on_name"
   end
 

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -2,12 +2,13 @@
 #
 # Table name: products
 #
-#  id         :bigint(8)        not null, primary key
-#  active     :boolean          default(FALSE), not null
-#  name       :string           not null
-#  price      :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :bigint(8)        not null, primary key
+#  active           :boolean          default(FALSE), not null
+#  event_activation :boolean          default(FALSE), not null
+#  name             :string           not null
+#  price            :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -19,3 +19,4 @@ one:
   name: EOS Account
   price: 3000
   active: true
+  event_activation: true

--- a/test/frontend/elm/Test/Component/Account/AccountComponent.elm
+++ b/test/frontend/elm/Test/Component/Account/AccountComponent.elm
@@ -50,7 +50,7 @@ tests =
                     Expect.equal (CreatedPage <| Created.initModel eosAccount publicKey) (getPage <| Route.CreatedRoute eosAccount publicKey)
             , test "EventCreationRoute" <|
                 \() ->
-                    Expect.equal NotFoundPage (getPage <| Route.EventCreationRoute <| Just "ko")
+                    Expect.equal (EventCreationPage EventCreation.initModel) (getPage <| Route.EventCreationRoute <| Just "ko")
             , test "NotFoundRoute" <|
                 \() -> Expect.equal NotFoundPage (getPage Route.NotFoundRoute)
             ]

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -2,12 +2,13 @@
 #
 # Table name: products
 #
-#  id         :bigint(8)        not null, primary key
-#  active     :boolean          default(FALSE), not null
-#  name       :string           not null
-#  price      :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :bigint(8)        not null, primary key
+#  active           :boolean          default(FALSE), not null
+#  event_activation :boolean          default(FALSE), not null
+#  name             :string           not null
+#  price            :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #


### PR DESCRIPTION
어드민에서 EOS Account 상품의 이벤트 활성화 여부를 제어함에 따라 이벤트 계정생성 페이지 진입을 제어할 수 있게 구현하였습니다. 추가로 이벤트 계정생성 api쪽에서도 이벤트 활성화 여부를 체크하도록하여 혹시나 이벤트 계정생성을 별도 api 호출로 요청하는 경우에도 대비하였습니다.