### PR TITLE
Fix the bug that pass the 0.0000 EOS when undelegate item is selected

### DIFF
--- a/app/frontend/src/elm/Component/Main/Page/Resource/Undelegate.elm
+++ b/app/frontend/src/elm/Component/Main/Page/Resource/Undelegate.elm
@@ -3,6 +3,8 @@ module Component.Main.Page.Resource.Undelegate exposing
     , Model
     , PercentageOfResource(..)
     , ResourceType(..)
+    , getEmptyStringIfZeroEos
+    , getNoOpIfZeroEos
     , getPercentageOfResource
     , initCmd
     , initModel
@@ -177,6 +179,7 @@ update message ({ undelegatebw, delegateListModal, unstakePossibleCpu, unstakePo
                     assetToFloat unstakePossibleCpu
                         * ratio
                         |> Round.round 4
+                        |> getEmptyStringIfZeroEos
 
                 newModel =
                     { model
@@ -198,6 +201,7 @@ update message ({ undelegatebw, delegateListModal, unstakePossibleCpu, unstakePo
                     assetToFloat unstakePossibleNet
                         * ratio
                         |> Round.round 4
+                        |> getEmptyStringIfZeroEos
 
                 newModel =
                     { model
@@ -239,13 +243,19 @@ update message ({ undelegatebw, delegateListModal, unstakePossibleCpu, unstakePo
                                 | undelegatebw =
                                     { undelegatebw
                                         | receiver = receiver
-                                        , unstakeCpuQuantity = cpu |> removeSymbolIfExists
-                                        , unstakeNetQuantity = net |> removeSymbolIfExists
+                                        , unstakeCpuQuantity =
+                                            cpu
+                                                |> removeSymbolIfExists
+                                                |> getEmptyStringIfZeroEos
+                                        , unstakeNetQuantity =
+                                            net
+                                                |> removeSymbolIfExists
+                                                |> getEmptyStringIfZeroEos
                                     }
                                 , unstakePossibleCpu = cpu
                                 , unstakePossibleNet = net
-                                , percentageOfCpu = Percentage100
-                                , percentageOfNet = Percentage100
+                                , percentageOfCpu = getNoOpIfZeroEos cpu Percentage100
+                                , percentageOfNet = getNoOpIfZeroEos net Percentage100
                                 , delegateListModal =
                                     { delegateListModal
                                         | isDelegateListModalOpened = False
@@ -524,3 +534,21 @@ getPercentageOfResource percentageOfResource =
 
         _ ->
             1
+
+
+getEmptyStringIfZeroEos : String -> String
+getEmptyStringIfZeroEos asset =
+    if assetToFloat asset == 0 then
+        ""
+
+    else
+        asset
+
+
+getNoOpIfZeroEos : String -> PercentageOfResource -> PercentageOfResource
+getNoOpIfZeroEos asset currentPercentage =
+    if assetToFloat asset == 0 then
+        NoOp
+
+    else
+        currentPercentage

--- a/test/frontend/elm/Test/Component/Main/Page/Resource/Undelegate.elm
+++ b/test/frontend/elm/Test/Component/Main/Page/Resource/Undelegate.elm
@@ -220,4 +220,32 @@ tests =
             ]
 
         -- TODO(boseok): validateText test. comment will be changed.
+        , describe "getEmptyStringIfZeroEos"
+            [ test "0.0000" <|
+                \() ->
+                    Expect.equal "" (getEmptyStringIfZeroEos "0.0000")
+            , test "0.0000 EOS" <|
+                \() ->
+                    Expect.equal "" (getEmptyStringIfZeroEos "0.0000 EOS")
+            , test "0.0003 EOS" <|
+                \() ->
+                    Expect.equal "0.0003 EOS" (getEmptyStringIfZeroEos "0.0003 EOS")
+            , test "0.0003" <|
+                \() ->
+                    Expect.equal "0.0003" (getEmptyStringIfZeroEos "0.0003")
+            ]
+        , describe "getNoOpIfZeroEos"
+            [ test "0.0000, Percentage100" <|
+                \() ->
+                    Expect.equal NoOp (getNoOpIfZeroEos "0.0000" Percentage100)
+            , test "0.0000 EOS" <|
+                \() ->
+                    Expect.equal NoOp (getNoOpIfZeroEos "0.0000 EOS" Percentage100)
+            , test "0.0003 EOS" <|
+                \() ->
+                    Expect.equal Percentage100 (getNoOpIfZeroEos "0.0003 EOS" Percentage100)
+            , test "0.0003" <|
+                \() ->
+                    Expect.equal Percentage100 (getNoOpIfZeroEos "0.0003" Percentage100)
+            ]
         ]


### PR DESCRIPTION
undelegatelist에서 아이템이 선택되었을 때 리소스가 0.0000 EOS인 경우 empty string을 값으로 전달하도록 변경